### PR TITLE
First pass Airflow DAG that runs the pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,4 +171,5 @@ cython_debug/
 .pypirc
 ami-connect/secrets.py
 
+airflow
 output

--- a/README.md
+++ b/README.md
@@ -5,15 +5,53 @@ Seamless pipelines for AMI water data, now as easy to access as turning on a tap
 
 Contributions should be reviewed and approved via a Pull Request to the `main` branch.
 
-This is a Python 3.13 project. To set up your local python environment, create a virtual environment with:
+This is a Python 3.12 project. To set up your local python environment, create a virtual environment with:
 
 ```
-python3.13 -m venv venv
+python3.12 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+You may need to install `rust` to get airflow to install. Follow instructions in the rust error message.
+
+### Testing
+
 Run unit tests with
 ```
 python -m unittest
+```
+
+### Airflow
+
+We use Apache Airflow to orchestrate our data pipeline. The Airflow code is in the `amicontrol` package.
+
+With the dependencies from `requirements.txt` installed, you should be able to run Airflow locally. First,
+set the AIRFLOW_HOME variable:
+
+```
+mkdir ./amicontrol/airflow && export AIRFLOW_HOME=`pwd`/amicontrol/airflow
+```
+
+If it's your first time, create the local Airflow app in `AIRFLOW_HOME` with:
+
+```
+airflow standalone
+```
+
+You'll want to modify the configuration to pick up our DAGs. In `$AIRFLOW_HOME/airflow.cfg`, change to these values:
+
+```
+dags_folder = {/your path to repo}/ami-connect/amicontrol/dags
+load_examples = False
+```
+
+Before you run `airflow standalone`, set these environment variables:
+```
+# This allows the DAG to import code from our other packages
+export PYTHONPATH="${PYTHONPATH}:./amiadapters"
+
+# This fixes hanging HTTP requests
+# https://stackoverflow.com/questions/75980623/why-is-my-airflow-hanging-up-if-i-send-a-http-request-inside-a-task
+export NO_PROXY="*"
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # ami-connect
+
 Seamless pipelines for AMI water data, now as easy to access as turning on a tap.
+
+## Project structure
+
+- [amiadapters](./amiadapters/) - Standalone Python library that adapts AMI data sources into our standard data format
+- [amicontrol](./amicontrol/) - The control plane for our AMI data pipeline. This houses Airflow DAGs and other code to operate the pipline.
+- [test](./test/) - Unittests for all python code in the project.
 
 ## Development
 
@@ -17,12 +24,12 @@ You may need to install `rust` to get airflow to install. Follow instructions in
 
 ### Testing
 
-Run unit tests with
+Run unit tests from the project's root directory with
 ```
 python -m unittest
 ```
 
-### Airflow
+### Run Airflow application
 
 We use Apache Airflow to orchestrate our data pipeline. The Airflow code is in the `amicontrol` package.
 
@@ -30,10 +37,11 @@ With the dependencies from `requirements.txt` installed, you should be able to r
 set the AIRFLOW_HOME variable:
 
 ```
-mkdir ./amicontrol/airflow && export AIRFLOW_HOME=`pwd`/amicontrol/airflow
+mkdir ./amicontrol/airflow
+export AIRFLOW_HOME=`pwd`/amicontrol/airflow
 ```
 
-If it's your first time, create the local Airflow app in `AIRFLOW_HOME` with:
+If it's your first time running the application on your machine, initialize the local Airflow app in `AIRFLOW_HOME` with:
 
 ```
 airflow standalone
@@ -48,10 +56,16 @@ load_examples = False
 
 Before you run `airflow standalone`, set these environment variables:
 ```
-# This allows the DAG to import code from our other packages
+# This allows the DAG to import code from this project's other Python packages
 export PYTHONPATH="${PYTHONPATH}:./amiadapters"
 
 # This fixes hanging HTTP requests
-# https://stackoverflow.com/questions/75980623/why-is-my-airflow-hanging-up-if-i-send-a-http-request-inside-a-task
+# See: https://stackoverflow.com/questions/75980623/why-is-my-airflow-hanging-up-if-i-send-a-http-request-inside-a-task
 export NO_PROXY="*"
 ```
+
+Re-run the command to start the application:
+```
+airflow standalone
+```
+Watch for the `admin` user and its password in `stdout`. Use those credentials to login. You should see our DAGs!

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+
+from airflow.decorators import dag, task
+
+from amiadapters.base import BaseAMIAdapter
+from amiadapters.beacon import Beacon360Adapter
+from amiadapters.config import AMIAdapterConfiguration
+from amiadapters.sentryx import SentryxAdapter
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2025, 3, 1),
+    catchup=False,
+    tags=["ami"],
+)
+def ami_control_dag():
+
+    config = AMIAdapterConfiguration.from_env()
+    adapters = [
+        SentryxAdapter(config),
+        Beacon360Adapter(config),
+    ]
+
+    @task()
+    def create_configuration():
+        
+        return {"config": config, "adapters": adapters}
+
+    @task()
+    def extract(adapter: BaseAMIAdapter):
+        adapter.extract()
+    
+    @task()
+    def transform(adapter: BaseAMIAdapter):
+        adapter.transform()
+
+    # config_data = create_configuration()
+    # import pdb; pdb.set_trace()
+    # for adapter in config_data["adapters"]:
+    for adapter in adapters:
+        extract.override(task_id=f"extract-{adapter.name()}")
+        extract(adapter)
+    
+    for adapter in adapters:
+        transform(adapter)
+
+
+ami_control_dag()

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -23,11 +23,6 @@ def ami_control_dag():
     ]
 
     @task()
-    def create_configuration():
-        
-        return {"config": config, "adapters": adapters}
-
-    @task()
     def extract(adapter: BaseAMIAdapter):
         adapter.extract()
     
@@ -35,15 +30,11 @@ def ami_control_dag():
     def transform(adapter: BaseAMIAdapter):
         adapter.transform()
 
-    # config_data = create_configuration()
-    # import pdb; pdb.set_trace()
-    # for adapter in config_data["adapters"]:
     for adapter in adapters:
-        extract.override(task_id=f"extract-{adapter.name()}")
-        extract(adapter)
+        extract.override(task_id=f"extract-{adapter.name()}")(adapter)
     
     for adapter in adapters:
-        transform(adapter)
+        transform.override(task_id=f"transform-{adapter.name()}")(adapter)
 
 
 ami_control_dag()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ idna==3.10
 python-dotenv==1.0.1
 requests==2.32.3
 urllib3==2.3.0
+# Installs with constraints for Python 3.12
+apache-airflow==2.10.5 --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.12.txt


### PR DESCRIPTION
This PR adds a new folder and an Airflow DAG that runs our extract and transform code. It also adds some setup instructions for the local Airflow app.

I was able to run the full (and still simple) pipeline in my local Airflow app. Nice!

CaDC folks, please be loud with your Airflow style preferences, this is my first DAG and I'd love your feedback.

Some next steps:
- We obviously need to add the Load part of the pipeline.
- We'll need to parameterize the DAG in a few ways. One major one would let us set a date range for extracted meter reads (should be easy). Another would be to allow our users to configure which adapters are run, and potentially run them for multiple utilities (still probably easy, but a little trickier).
- This DAG stores intermediate datasets as local files. Our prod pipeline should store them in S3 and/or Snowflake.
- This DAG would run fine on a large EC2 server, ala CaDC's pipeline. It might not run on whatever AWS infrastructure we ultimately pick, where we'd need different operators that might be specific to the infrastructure, like a Lambda operator.