### PR TITLE
Load raw and transformed data into Snowflake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,11 @@ BEACON_AUTH_USER=beacon_user
 BEACON_AUTH_PASSWORD=beacon_password
 AMI_DATA_OUTPUT_FOLDER="./output"
 UTILITY_NAME=my-utility
+
+SNOWFLAKE_USER=snowflake
+SNOWFLAKE_PASSWORD=snowflake_password
+SNOWFLAKE_ACCOUNT=snowflake_account
+SNOWFLAKE_WAREHOUSE=snowflake_warehouse
+SNOWFLAKE_DATABASE=snowflake_database
+SNOWFLAKE_SCHEMA=snowflake_schema
+SNOWFLAKE_ROLE=snowflake_role

--- a/amiadapters/base.py
+++ b/amiadapters/base.py
@@ -2,6 +2,10 @@ from abc import ABC, abstractmethod
 import dataclasses
 from datetime import datetime
 import json
+from typing import List
+
+from amiadapters.config import AMIAdapterConfiguration
+from amiadapters.storage.base import BaseAMIStorageAdapter
 
 
 class BaseAMIAdapter(ABC):
@@ -10,6 +14,9 @@ class BaseAMIAdapter(ABC):
     you'll inherit from this class and implement its abstract methods. That should
     set you up to include it in our data pipeline.
     """
+
+    def __init__(self, storage_adapters: List[BaseAMIStorageAdapter] = None):
+        self.storage_adapters = storage_adapters if storage_adapters is not None else []
 
     @abstractmethod
     def name(self) -> str:
@@ -22,6 +29,14 @@ class BaseAMIAdapter(ABC):
     @abstractmethod
     def transform(self):
         pass
+
+    def load_raw(self, config: AMIAdapterConfiguration):
+        for storage_adapter in self.storage_adapters:
+            storage_adapter.store_raw(config)
+
+    def load_transformed(self, config: AMIAdapterConfiguration):
+        for storage_adapter in self.storage_adapters:
+            storage_adapter.store_transformed(config)
 
     def datetime_from_iso_str(self, datetime_str: str, org_timezone: str) -> datetime:
         # TODO timezones

--- a/amiadapters/base.py
+++ b/amiadapters/base.py
@@ -5,7 +5,7 @@ import json
 from typing import List
 
 from amiadapters.config import AMIAdapterConfiguration
-from amiadapters.storage.base import BaseAMIStorageAdapter
+from amiadapters.storage.base import BaseAMIStorageSink
 
 
 class BaseAMIAdapter(ABC):
@@ -15,7 +15,7 @@ class BaseAMIAdapter(ABC):
     set you up to include it in our data pipeline.
     """
 
-    def __init__(self, storage_adapters: List[BaseAMIStorageAdapter] = None):
+    def __init__(self, storage_adapters: List[BaseAMIStorageSink] = None):
         self.storage_adapters = storage_adapters if storage_adapters is not None else []
 
     @abstractmethod

--- a/amiadapters/base.py
+++ b/amiadapters/base.py
@@ -15,8 +15,8 @@ class BaseAMIAdapter(ABC):
     set you up to include it in our data pipeline.
     """
 
-    def __init__(self, storage_adapters: List[BaseAMIStorageSink] = None):
-        self.storage_adapters = storage_adapters if storage_adapters is not None else []
+    def __init__(self, storage_sinks: List[BaseAMIStorageSink] = None):
+        self.storage_sinks = storage_sinks if storage_sinks is not None else []
 
     @abstractmethod
     def name(self) -> str:
@@ -31,12 +31,12 @@ class BaseAMIAdapter(ABC):
         pass
 
     def load_raw(self, config: AMIAdapterConfiguration):
-        for storage_adapter in self.storage_adapters:
-            storage_adapter.store_raw(config)
+        for sink in self.storage_sinks:
+            sink.store_raw(config)
 
     def load_transformed(self, config: AMIAdapterConfiguration):
-        for storage_adapter in self.storage_adapters:
-            storage_adapter.store_transformed(config)
+        for sink in self.storage_sinks:
+            sink.store_transformed(config)
 
     def datetime_from_iso_str(self, datetime_str: str, org_timezone: str) -> datetime:
         # TODO timezones

--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -268,9 +268,9 @@ class Beacon360Adapter(BaseAMIAdapter):
         self.use_cache = True
         storage_sinks = [
             BeaconSnowflakeStorageSink(
-                self._transformed_meter_output_file(), 
-                self._transformed_reads_output_file(), 
-                self._raw_reads_output_file()
+                self._transformed_meter_output_file(),
+                self._transformed_reads_output_file(),
+                self._raw_reads_output_file(),
             )
         ]
         super().__init__(storage_sinks)
@@ -536,7 +536,12 @@ class BeaconSnowflakeStorageSink(SnowflakeStorageSink):
     data, this stores raw meters and reads into a Snowflake table.
     """
 
-    def __init__(self, transformed_meter_file: str, transformed_reads_file: str, raw_meter_and_reads_file: str):
+    def __init__(
+        self,
+        transformed_meter_file: str,
+        transformed_reads_file: str,
+        raw_meter_and_reads_file: str,
+    ):
         super().__init__(transformed_meter_file, transformed_reads_file)
         self.raw_meter_and_reads_file = raw_meter_and_reads_file
 
@@ -555,7 +560,7 @@ class BeaconSnowflakeStorageSink(SnowflakeStorageSink):
             database=config.snowflake_database,
             schema=config.snowflake_schema,
             role=config.snowflake_role,
-            paramstyle='qmark',
+            paramstyle="qmark",
         )
 
         create_temp_table_sql = "CREATE OR REPLACE TEMPORARY TABLE temp_beacon_360_base LIKE beacon_360_base;"
@@ -569,7 +574,10 @@ class BeaconSnowflakeStorageSink(SnowflakeStorageSink):
         """
         created_time = datetime.now(tz=pytz.UTC)
         rows = [
-            tuple(["my-org", i.Meter_ID, created_time] + [i.__getattribute__(name) for name in REQUESTED_COLUMNS])
+            tuple(
+                ["my-org", i.Meter_ID, created_time]
+                + [i.__getattribute__(name) for name in REQUESTED_COLUMNS]
+            )
             for i in raw_meters_with_reads
         ]
         conn.cursor().executemany(insert_temp_data_sql, rows)

--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -5,9 +5,12 @@ from io import StringIO
 import json
 import logging
 import os
+import pytz
 import requests
 import time
 from typing import List, Tuple
+
+import snowflake.connector
 
 from amiadapters.base import (
     BaseAMIAdapter,
@@ -17,6 +20,7 @@ from amiadapters.base import (
     GeneralModelJSONEncoder,
 )
 from amiadapters.config import AMIAdapterConfiguration
+from amiadapters.storage.snowflake import SnowflakeStorageAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +43,7 @@ REQUESTED_COLUMNS = [
     "Billing_City",
     "Billing_Country",
     "Billing_State",
-    "Billing_Zip",
+    "Billing_ZIP",
     "Connector_Type",
     "Current_Leak_Rate",
     "Current_Leak_Start_Date",
@@ -83,7 +87,7 @@ REQUESTED_COLUMNS = [
     "Location_State",
     "Location_Water_Type",
     "Location_Year_Built",
-    "Location_Zip",
+    "Location_ZIP",
     "Low_Read_Limit",
     "Meter_Continuous_Flow",
     "Meter_ID",
@@ -262,6 +266,14 @@ class Beacon360Adapter(BaseAMIAdapter):
         # Probably don't want to use this in production
         # TODO expose this in settings, maybe make it default false?
         self.use_cache = True
+        storage_adapters = [
+            BeaconSnowflakeStorageAdapter(
+                self._transformed_meter_output_file(), 
+                self._transformed_reads_output_file(), 
+                self._raw_reads_output_file()
+            )
+        ]
+        super().__init__(storage_adapters)
 
     def name(self) -> str:
         return f"beacon-360-api"
@@ -516,3 +528,44 @@ class Beacon360Adapter(BaseAMIAdapter):
 
     def _transformed_reads_output_file(self) -> str:
         return os.path.join(self.output_folder, f"{self.name()}-transformed-reads.txt")
+
+
+
+class BeaconSnowflakeStorageAdapter(SnowflakeStorageAdapter):
+
+    def __init__(self, transformed_meter_file: str, transformed_reads_file: str, raw_meter_and_reads_file: str):
+        super().__init__(transformed_meter_file, transformed_reads_file)
+        self.raw_meter_and_reads_file = raw_meter_and_reads_file
+
+    def store_raw(self, config: AMIAdapterConfiguration):
+        with open(self.raw_meter_and_reads_file, "r") as f:
+            text = f.read()
+            raw_meters_with_reads = [
+                Beacon360MeterAndRead(**json.loads(d)) for d in text.strip().split("\n")
+            ]
+
+        conn = snowflake.connector.connect(
+            account=config.snowflake_account,
+            user=config.snowflake_user,
+            password=config.snowflake_password,
+            warehouse=config.snowflake_warehouse,
+            database=config.snowflake_database,
+            schema=config.snowflake_schema,
+            role=config.snowflake_role,
+            paramstyle='qmark',
+        )
+
+        columns = ", ".join(REQUESTED_COLUMNS)
+        qmarks = "?, " * (len(REQUESTED_COLUMNS) - 1) + "?"
+        sql = f"""
+            INSERT INTO beacon_360_base (org_id, device_id, created_time, {columns}) 
+                VALUES (?, ?, ?, {qmarks})
+        """
+        created_time = datetime.now(tz=pytz.UTC)
+
+        rows = [
+            tuple(["my-org", i.Meter_ID, created_time] + [i.__getattribute__(name) for name in REQUESTED_COLUMNS])
+            for i in raw_meters_with_reads
+        ]
+
+        conn.cursor().executemany(sql, rows)

--- a/amiadapters/config.py
+++ b/amiadapters/config.py
@@ -11,20 +11,29 @@ class AMIAdapterConfiguration:
         self.sentryx_api_key = kwargs.get("sentryx_api_key")
         self.beacon_360_user = kwargs.get("beacon_360_user")
         self.beacon_360_password = kwargs.get("beacon_360_password")
+        self.snowflake_user = kwargs.get("snowflake_user")
+        self.snowflake_password = kwargs.get("snowflake_password")
+        self.snowflake_account = kwargs.get("snowflake_account")
+        self.snowflake_warehouse = kwargs.get("snowflake_warehouse")
+        self.snowflake_database = kwargs.get("snowflake_database")
+        self.snowflake_schema = kwargs.get("snowflake_schema")
+        self.snowflake_role = kwargs.get("snowflake_role")
 
     @classmethod
     def from_env(cls):
         # Assumes .env file in working directory
         load_dotenv()
-        utility_name = os.environ.get("UTILITY_NAME")
-        output_folder = os.environ.get("AMI_DATA_OUTPUT_FOLDER")
-        sentryx_api_key = os.environ.get("SENTRYX_API_KEY")
-        beacon_360_user = os.environ.get("BEACON_AUTH_USER")
-        beacon_360_password = os.environ.get("BEACON_AUTH_PASSWORD")
         return AMIAdapterConfiguration(
-            utility_name=utility_name,
-            output_folder=output_folder,
-            sentryx_api_key=sentryx_api_key,
-            beacon_360_user=beacon_360_user,
-            beacon_360_password=beacon_360_password,
+            utility_name=os.environ.get("UTILITY_NAME"),
+            output_folder=os.environ.get("AMI_DATA_OUTPUT_FOLDER"),
+            sentryx_api_key=os.environ.get("SENTRYX_API_KEY"),
+            beacon_360_user=os.environ.get("BEACON_AUTH_USER"),
+            beacon_360_password=os.environ.get("BEACON_AUTH_PASSWORD"),
+            snowflake_user=os.environ.get("SNOWFLAKE_USER"),
+            snowflake_password=os.environ.get("SNOWFLAKE_PASSWORD"),
+            snowflake_account=os.environ.get("SNOWFLAKE_ACCOUNT"),
+            snowflake_warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE"),
+            snowflake_database=os.environ.get("SNOWFLAKE_DATABASE"),
+            snowflake_schema=os.environ.get("SNOWFLAKE_SCHEMA"),
+            snowflake_role=os.environ.get("SNOWFLAKE_ROLE"),
         )

--- a/amiadapters/run.py
+++ b/amiadapters/run.py
@@ -43,12 +43,14 @@ def run_extract_transform():
         logger.info(f"Loaded raw data for {adapter.name()} to {config.output_folder}")
 
     logger.info(f"Loaded raw data for {len(adapters)} adapters")
-    
+
     for adapter in adapters:
         logger.info(
             f"Loading transformed data for {adapter.name()} from {config.output_folder}"
         )
         adapter.load_transformed(config)
-        logger.info(f"Loaded transformed data for {adapter.name()} to {config.output_folder}")
+        logger.info(
+            f"Loaded transformed data for {adapter.name()} to {config.output_folder}"
+        )
 
     logger.info(f"Loaded transformed data for {len(adapters)} adapters")

--- a/amiadapters/run.py
+++ b/amiadapters/run.py
@@ -1,5 +1,7 @@
 import logging
 
+import snowflake.connector
+
 from amiadapters.beacon import Beacon360Adapter
 from amiadapters.config import AMIAdapterConfiguration
 from amiadapters.sentryx import SentryxAdapter
@@ -13,9 +15,10 @@ def run_extract_transform():
     """
     config = AMIAdapterConfiguration.from_env()
     adapters = [
-        SentryxAdapter(config),
+        # SentryxAdapter(config),
         Beacon360Adapter(config),
     ]
+
     for adapter in adapters:
         logger.info(f"Extracting data for {adapter.name()}")
         adapter.extract()
@@ -31,3 +34,21 @@ def run_extract_transform():
         logger.info(f"Transformed data for {adapter.name()} to {config.output_folder}")
 
     logger.info(f"Transformed data for {len(adapters)} adapters")
+
+    for adapter in adapters:
+        logger.info(
+            f"Loading raw data for {adapter.name()} from {config.output_folder}"
+        )
+        adapter.load_raw(config)
+        logger.info(f"Loaded raw data for {adapter.name()} to {config.output_folder}")
+
+    logger.info(f"Loaded raw data for {len(adapters)} adapters")
+    
+    for adapter in adapters:
+        logger.info(
+            f"Loading transformed data for {adapter.name()} from {config.output_folder}"
+        )
+        adapter.load_transformed(config)
+        logger.info(f"Loaded transformed data for {adapter.name()} to {config.output_folder}")
+
+    logger.info(f"Loaded transformed data for {len(adapters)} adapters")

--- a/amiadapters/storage/base.py
+++ b/amiadapters/storage/base.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from amiadapters.config import AMIAdapterConfiguration
 
 
-class BaseAMIStorageAdapter(ABC):
+class BaseAMIStorageSink(ABC):
 
     def __init__(self, transformed_meter_file: str, transformed_reads_file):
         self.transformed_meter_file = transformed_meter_file

--- a/amiadapters/storage/base.py
+++ b/amiadapters/storage/base.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+
+from amiadapters.config import AMIAdapterConfiguration
+
+
+class BaseAMIStorageAdapter(ABC):
+
+    def __init__(self, transformed_meter_file: str, transformed_reads_file):
+        self.transformed_meter_file = transformed_meter_file
+        self.transformed_reads_file = transformed_reads_file
+
+    @abstractmethod
+    def store_raw(self, config: AMIAdapterConfiguration):
+        pass
+
+    @abstractmethod
+    def store_transformed(self, config: AMIAdapterConfiguration):
+        pass

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -1,0 +1,114 @@
+from datetime import datetime
+import json
+import pytz
+
+import snowflake.connector
+
+from amiadapters.base import GeneralMeter, GeneralMeterRead
+from amiadapters.config import AMIAdapterConfiguration
+from amiadapters.storage.base import BaseAMIStorageAdapter
+
+
+class SnowflakeStorageAdapter(BaseAMIStorageAdapter):
+
+    def __init__(self, transformed_meter_file: str, transformed_reads_file: str):
+        super().__init__(transformed_meter_file, transformed_reads_file)
+
+    def store_transformed(self, config: AMIAdapterConfiguration):
+        with open(self.transformed_meter_file, "r") as f:
+            text = f.read()
+            meters = [GeneralMeter(**json.loads(d)) for d in text.strip().split("\n")]
+
+        with open(self.transformed_reads_file, "r") as f:
+            text = f.read()
+            reads = [GeneralMeterRead(**json.loads(d)) for d in text.strip().split("\n")]
+
+        conn = snowflake.connector.connect(
+            account=config.snowflake_account,
+            user=config.snowflake_user,
+            password=config.snowflake_password,
+            warehouse=config.snowflake_warehouse,
+            database=config.snowflake_database,
+            schema=config.snowflake_schema,
+            role=config.snowflake_role,
+            paramstyle='qmark',
+        )
+
+        sql = "CREATE OR REPLACE TEMPORARY TABLE TEMP_METERS LIKE METERS;"
+        conn.cursor().execute(sql)
+
+        row_active_from = datetime.now(tz=pytz.UTC)
+
+        sql = """
+            INSERT INTO temp_meters (
+                org_id, device_id, account_id, location_id, meter_id, 
+                endpoint_id, meter_install_date, meter_size, meter_manufacturer, 
+                multiplier, location_address, location_city, location_state, location_zip,
+                row_active_from
+            ) 
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
+        rows = [self._meter_tuple(m, row_active_from) for m in meters]
+        # import pdb; pdb.set_trace()
+        conn.cursor().executemany(sql, rows)
+
+        merge_sql = f"""
+            MERGE INTO meters AS target
+            USING(
+                SELECT
+                    *
+                FROM
+                    temp_meters
+            ) AS source
+
+            ON target.org_id = source.org_id 
+                AND target.device_id = source.device_id
+            WHEN MATCHED THEN
+                UPDATE SET
+                    target.account_id = source.account_id,
+                    target.location_id = source.location_id,
+                    target.meter_id = source.meter_id,
+                    target.endpoint_id = source.endpoint_id,
+                    target.meter_install_date = source.meter_install_date,
+                    target.meter_size = source.meter_size,
+                    target.meter_manufacturer = source.meter_manufacturer,
+                    target.multiplier = source.multiplier,
+                    target.location_address = source.location_address,
+                    target.location_city = source.location_city,
+                    target.location_state = source.location_state,
+                    target.location_zip = source.location_zip,
+                    target.row_active_until = source.row_active_from
+            WHEN NOT MATCHED THEN
+                INSERT (org_id, device_id, account_id, location_id, meter_id, 
+                        endpoint_id, meter_install_date, meter_size, meter_manufacturer, 
+                        multiplier, location_address, location_city, location_state, location_zip,
+                        row_active_from)
+                VALUES (source.org_id, source.device_id, source.account_id, source.location_id, source.meter_id, 
+                        source.endpoint_id, source.meter_install_date, source.meter_size, source.meter_manufacturer, 
+                        source.multiplier, source.location_address, source.location_city, source.location_state, source.location_zip,
+                        source.row_active_from);
+        """
+        conn.cursor().execute(merge_sql)
+    
+    def _meter_tuple(self, meter: GeneralMeter, row_active_from: datetime):
+        result = [
+            "org_id",
+            meter.device_id,
+            meter.account_id,
+            meter.location_id,
+            meter.meter_id,
+            meter.endpoint_id,
+            meter.meter_install_date,
+            meter.meter_size,
+            meter.meter_manufacturer,
+            meter.multiplier,
+            meter.location_address,
+            None,
+            meter.location_state,
+            meter.location_zip,
+            row_active_from
+        ]
+        return tuple(result)
+        
+
+

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from airflow.decorators import dag, task
+import snowflake.connector
 
 from amiadapters.base import BaseAMIAdapter
 from amiadapters.beacon import Beacon360Adapter
@@ -18,7 +19,7 @@ def ami_control_dag():
 
     config = AMIAdapterConfiguration.from_env()
     adapters = [
-        SentryxAdapter(config),
+        # SentryxAdapter(config),
         Beacon360Adapter(config),
     ]
 

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -29,11 +29,11 @@ def ami_control_dag():
     @task()
     def transform(adapter: BaseAMIAdapter):
         adapter.transform()
-    
+
     @task()
     def load_raw(adapter: BaseAMIAdapter, config: AMIAdapterConfiguration):
         adapter.load_raw(config)
-    
+
     @task()
     def load_transformed(adapter: BaseAMIAdapter, config: AMIAdapterConfiguration):
         adapter.load_transformed(config)
@@ -43,12 +43,14 @@ def ami_control_dag():
 
     for adapter in adapters:
         transform.override(task_id=f"transform-{adapter.name()}")(adapter)
-    
+
     for adapter in adapters:
         load_raw.override(task_id=f"load-raw-{adapter.name()}")(adapter, config)
-    
+
     for adapter in adapters:
-        load_transformed.override(task_id=f"load-transformed-{adapter.name()}")(adapter, config)
+        load_transformed.override(task_id=f"load-transformed-{adapter.name()}")(
+            adapter, config
+        )
 
 
 ami_control_dag()

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from airflow.decorators import dag, task
-import snowflake.connector
 
 from amiadapters.base import BaseAMIAdapter
 from amiadapters.beacon import Beacon360Adapter

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -30,12 +30,26 @@ def ami_control_dag():
     @task()
     def transform(adapter: BaseAMIAdapter):
         adapter.transform()
+    
+    @task()
+    def load_raw(adapter: BaseAMIAdapter, config: AMIAdapterConfiguration):
+        adapter.load_raw(config)
+    
+    @task()
+    def load_transformed(adapter: BaseAMIAdapter, config: AMIAdapterConfiguration):
+        adapter.load_transformed(config)
 
     for adapter in adapters:
         extract.override(task_id=f"extract-{adapter.name()}")(adapter)
 
     for adapter in adapters:
         transform.override(task_id=f"transform-{adapter.name()}")(adapter)
+    
+    for adapter in adapters:
+        load_raw.override(task_id=f"load-raw-{adapter.name()}")(adapter, config)
+    
+    for adapter in adapters:
+        load_transformed.override(task_id=f"load-transformed-{adapter.name()}")(adapter, config)
 
 
 ami_control_dag()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ urllib3==2.3.0
 black==25.1.0
 # Installs with constraints for Python 3.12
 apache-airflow==2.10.5 --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.12.txt
+apache-airflow-providers-snowflake==6.1.1


### PR DESCRIPTION
This uses the Beacon 360 example to raw and transformed data into Snowflake. I'm able to run it on my local Airflow instance via the DAG we've been using.

The PR adds two functions to our abstract adapter class: `load_raw` and `load_transformed`. They delegate to "storage sinks", which are a new concept here. A storage sink should tell the pipeline how to store data into some storage solution (Snowflake, here). Since each AMI data source will have its own raw data format, we'll have a storage sink implementation for each AMI source + storage solution combo.

I'm hoping that a user can someday use the composition here to mix and match which storage solutions they want to use. I'm planning to make this part of the pipeline configuration that they'd set up. They should someday be able to use this to add multiple storage sinks to the pipeline, configure whether they want to store the raw data, etc.