### PR TITLE
Use org_id and org_timezone from configuration

### DIFF
--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -306,10 +306,13 @@ class Beacon360Adapter(BaseAMIAdapter):
         Retrieve from cache if configured to do so.
         """
         if self.use_cache:
+            logger.info("Attempting to load report from cache")
             cached_report = self._get_cached_report()
             if cached_report is not None:
-                logger.info("Loading report from cache")
+                logger.info("Loaded report from cache")
                 return cached_report
+            else:
+                logger.info("Could not load report from cache, continuing with calls to API")
 
         auth = requests.auth.HTTPBasicAuth(self.user, self.password)
 

--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -289,7 +289,7 @@ class Beacon360Adapter(BaseAMIAdapter):
         super().__init__(storage_sinks)
 
     def name(self) -> str:
-        return f"beacon-360-api"
+        return f"beacon-360-{self.org_id}"
 
     def extract(self):
         report = self._fetch_range_report()
@@ -504,7 +504,9 @@ class Beacon360Adapter(BaseAMIAdapter):
             )
             transformed_meters.add(meter)
 
-            flowtime = self.datetime_from_iso_str(meter_and_read.Read_Time, self.org_timezone)
+            flowtime = self.datetime_from_iso_str(
+                meter_and_read.Read_Time, self.org_timezone
+            )
             if flowtime is None:
                 logger.info(
                     f"Skipping read with no flowtime for account={account_id} location={location_id} meter={meter_id}"

--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -312,7 +312,9 @@ class Beacon360Adapter(BaseAMIAdapter):
                 logger.info("Loaded report from cache")
                 return cached_report
             else:
-                logger.info("Could not load report from cache, continuing with calls to API")
+                logger.info(
+                    "Could not load report from cache, continuing with calls to API"
+                )
 
         auth = requests.auth.HTTPBasicAuth(self.user, self.password)
 

--- a/amiadapters/config.py
+++ b/amiadapters/config.py
@@ -88,6 +88,7 @@ class AMIAdapterConfiguration:
                 source.get("timezone"),
                 source.get("use_raw_data_cache"),
                 source.get("intermediate_output"),
+                source.get("utility_name"),
                 secrets,
                 sinks,
             )
@@ -126,6 +127,8 @@ class AMIAdapterConfiguration:
                             source.intermediate_output,
                             source.secrets.api_key,
                             source.org_id,
+                            source.timezone,
+                            source.utility_name,
                         )
                     )
         return adapters
@@ -226,6 +229,7 @@ class ConfiguredAMISource:
         timezone: str,
         use_raw_data_cache: bool,
         intermediate_output: str,
+        utility_name: str,
         secrets: Union[Beacon360Secrets],
         sinks: List[ConfiguredStorageSink],
     ):
@@ -234,6 +238,7 @@ class ConfiguredAMISource:
         self.timezone = self._timezone(timezone)
         self.use_raw_data_cache = bool(use_raw_data_cache)
         self.intermediate_output = self._intermediate_output(intermediate_output)
+        self.utility_name = utility_name
         self.secrets = self._secrets(secrets)
         self.storage_sinks = self._sinks(sinks)
 

--- a/amiadapters/config.py
+++ b/amiadapters/config.py
@@ -97,6 +97,10 @@ class AMIAdapterConfiguration:
         return AMIAdapterConfiguration(sources=sources)
 
     def adapters(self):
+        """
+        Preferred method for instantiating AMI Adapters off of a user's configuration.
+        Reads configuration to see which adapters to run and where to store the data.
+        """
         # Circular import, TODO fix
         from amiadapters.beacon import Beacon360Adapter
         from amiadapters.sentryx import SentryxAdapter
@@ -111,6 +115,8 @@ class AMIAdapterConfiguration:
                             source.secrets.password,
                             source.intermediate_output,
                             source.use_raw_data_cache,
+                            source.org_id,
+                            source.timezone,
                             source.storage_sinks,
                         )
                     )

--- a/test/amiadapters/test_beacon.py
+++ b/test/amiadapters/test_beacon.py
@@ -1,4 +1,5 @@
 import datetime
+import pytz
 from unittest import mock
 
 from amiadapters.base import GeneralMeter, GeneralMeterRead
@@ -87,6 +88,8 @@ class TestBeacon360Adapter(BaseTestCase):
             api_password="pass",
             intermediate_output="output",
             use_cache=False,
+            org_id="this-org",
+            org_timezone=pytz.timezone("Europe/Rome"),
             configured_sinks=[],
         )
 
@@ -136,11 +139,11 @@ class TestBeacon360Adapter(BaseTestCase):
             generater_report_request.kwargs["params"]["Header_Columns"],
         )
         self.assertEqual(
-            datetime.datetime(2024, 8, 1, 0, 0),
+            datetime.datetime(2024, 8, 1, 0, 0, tzinfo=pytz.timezone('Europe/Rome')),
             generater_report_request.kwargs["params"]["Start_Date"],
         )
         self.assertEqual(
-            datetime.datetime(2024, 8, 2, 0, 0),
+            datetime.datetime(2024, 8, 2, 0, 0, tzinfo=pytz.timezone('Europe/Rome')),
             generater_report_request.kwargs["params"]["End_Date"],
         )
         self.assertTrue(generater_report_request.kwargs["params"]["Has_Endpoint"])
@@ -219,9 +222,9 @@ class TestBeacon360Adapter(BaseTestCase):
 
         self.assertTrue("Exception found in report status" in str(context.exception))
 
-    # Mock the status call response as "not finished" twenty times
+    # Mock the status call response as "not finished" 50 times
     @mock.patch(
-        "requests.get", side_effect=[mocked_get_range_report_status_not_finished()] * 20
+        "requests.get", side_effect=[mocked_get_range_report_status_not_finished()] * 50
     )
     @mock.patch("requests.post", side_effect=[mocked_create_range_report()])
     @mock.patch("time.sleep")
@@ -711,7 +714,7 @@ class TestBeacon360Adapter(BaseTestCase):
 
         expected_meters = [
             GeneralMeter(
-                org_id="my org",
+                org_id="this-org",
                 device_id="1470158170",
                 account_id="303022",
                 location_id="303022",
@@ -730,7 +733,7 @@ class TestBeacon360Adapter(BaseTestCase):
 
         expected_reads = [
             GeneralMeterRead(
-                org_id="my org",
+                org_id="this-org",
                 device_id="1470158170",
                 account_id="303022",
                 location_id="303022",
@@ -741,7 +744,7 @@ class TestBeacon360Adapter(BaseTestCase):
                 interval_unit=None,
             ),
             GeneralMeterRead(
-                org_id="my org",
+                org_id="this-org",
                 device_id="1470158170",
                 account_id="303022",
                 location_id="303022",
@@ -979,7 +982,7 @@ class TestBeacon360Adapter(BaseTestCase):
 
         expected_meters = [
             GeneralMeter(
-                org_id="my org",
+                org_id="this-org",
                 device_id="10101",
                 account_id="1",
                 location_id="303022",
@@ -994,7 +997,7 @@ class TestBeacon360Adapter(BaseTestCase):
                 location_zip="93727",
             ),
             GeneralMeter(
-                org_id="my org",
+                org_id="this-org",
                 device_id="1470158170",
                 account_id="303022",
                 location_id="303022",
@@ -1013,7 +1016,7 @@ class TestBeacon360Adapter(BaseTestCase):
 
         expected_reads = [
             GeneralMeterRead(
-                org_id="my org",
+                org_id="this-org",
                 device_id="1470158170",
                 account_id="303022",
                 location_id="303022",
@@ -1024,7 +1027,7 @@ class TestBeacon360Adapter(BaseTestCase):
                 interval_unit=None,
             ),
             GeneralMeterRead(
-                org_id="my org",
+                org_id="this-org",
                 device_id="10101",
                 account_id="1",
                 location_id="303022",
@@ -1155,7 +1158,7 @@ class TestBeacon360Adapter(BaseTestCase):
 
         expected_meters = [
             GeneralMeter(
-                org_id="my org",
+                org_id="this-org",
                 device_id="1470158170",
                 account_id="303022",
                 location_id="303022",

--- a/test/amiadapters/test_beacon.py
+++ b/test/amiadapters/test_beacon.py
@@ -97,7 +97,7 @@ class TestBeacon360Adapter(BaseTestCase):
         self.assertEqual("output", self.adapter.output_folder)
         self.assertEqual("user", self.adapter.user)
         self.assertEqual("pass", self.adapter.password)
-        self.assertEqual("beacon-360-api", self.adapter.name())
+        self.assertEqual("beacon-360-this-org", self.adapter.name())
 
     @mock.patch("requests.get")
     @mock.patch("requests.post")
@@ -139,11 +139,11 @@ class TestBeacon360Adapter(BaseTestCase):
             generater_report_request.kwargs["params"]["Header_Columns"],
         )
         self.assertEqual(
-            datetime.datetime(2024, 8, 1, 0, 0, tzinfo=pytz.timezone('Europe/Rome')),
+            datetime.datetime(2024, 8, 1, 0, 0, tzinfo=pytz.timezone("Europe/Rome")),
             generater_report_request.kwargs["params"]["Start_Date"],
         )
         self.assertEqual(
-            datetime.datetime(2024, 8, 2, 0, 0, tzinfo=pytz.timezone('Europe/Rome')),
+            datetime.datetime(2024, 8, 2, 0, 0, tzinfo=pytz.timezone("Europe/Rome")),
             generater_report_request.kwargs["params"]["End_Date"],
         )
         self.assertTrue(generater_report_request.kwargs["params"]["Has_Endpoint"])

--- a/test/amiadapters/test_config.py
+++ b/test/amiadapters/test_config.py
@@ -16,6 +16,7 @@ class TestConfig(BaseTestCase):
         source = config.sources[0]
         self.assertEqual("sentryx", source.type)
         self.assertEqual("my_utility", source.org_id)
+        self.assertEqual("u_name", source.utility_name)
         self.assertEqual("America/Los_Angeles", str(source.timezone))
         self.assertEqual(False, source.use_raw_data_cache)
         self.assertEqual("./output", source.intermediate_output)

--- a/test/amiadapters/test_sentryx.py
+++ b/test/amiadapters/test_sentryx.py
@@ -1,4 +1,5 @@
 import datetime
+import pytz
 from unittest import mock
 
 from amiadapters.base import GeneralMeter, GeneralMeterRead
@@ -146,14 +147,20 @@ class TestSentryxAdapter(BaseTestCase):
 
     def setUp(self):
         self.adapter = SentryxAdapter(
-            intermediate_output="output", api_key="key", org_id="my-utility"
+            intermediate_output="output",
+            api_key="key",
+            org_id="this-utility",
+            org_timezone=pytz.timezone("Africa/Algiers"),
+            utility_name="my-utility-name",
         )
 
     def test_init(self):
         self.assertEqual("output", self.adapter.output_folder)
         self.assertEqual("key", self.adapter.api_key)
-        self.assertEqual("my-utility", self.adapter.utility)
-        self.assertEqual("sentryx-api-my-utility", self.adapter.name())
+        self.assertEqual("this-utility", self.adapter.org_id)
+        self.assertEqual(pytz.timezone("Africa/Algiers"), self.adapter.org_timezone)
+        self.assertEqual("my-utility-name", self.adapter.utility_name)
+        self.assertEqual("sentryx-api-this-utility", self.adapter.name())
 
     @mock.patch(
         "requests.get",
@@ -185,12 +192,12 @@ class TestSentryxAdapter(BaseTestCase):
 
         calls = [
             mock.call(
-                "https://api.sentryx.io/v1-wm/sites/my-utility/devices",
+                "https://api.sentryx.io/v1-wm/sites/my-utility-name/devices",
                 headers={"Authorization": "key"},
                 params={"pager.skip": 0, "pager.take": 25},
             ),
             mock.call(
-                "https://api.sentryx.io/v1-wm/sites/my-utility/devices",
+                "https://api.sentryx.io/v1-wm/sites/my-utility-name/devices",
                 headers={"Authorization": "key"},
                 params={"pager.skip": 1, "pager.take": 25},
             ),
@@ -236,7 +243,7 @@ class TestSentryxAdapter(BaseTestCase):
 
         calls = [
             mock.call(
-                "https://api.sentryx.io/v1-wm/sites/my-utility/devices/consumption",
+                "https://api.sentryx.io/v1-wm/sites/my-utility-name/devices/consumption",
                 headers={"Authorization": "key"},
                 params={
                     "skip": 0,
@@ -246,7 +253,7 @@ class TestSentryxAdapter(BaseTestCase):
                 },
             ),
             mock.call(
-                "https://api.sentryx.io/v1-wm/sites/my-utility/devices/consumption",
+                "https://api.sentryx.io/v1-wm/sites/my-utility-name/devices/consumption",
                 headers={"Authorization": "key"},
                 params={
                     "skip": 2,
@@ -310,7 +317,7 @@ class TestSentryxAdapter(BaseTestCase):
 
         expected_meters = [
             GeneralMeter(
-                org_id="my org",
+                org_id="this-utility",
                 device_id="1",
                 account_id="101",
                 location_id=None,
@@ -328,7 +335,7 @@ class TestSentryxAdapter(BaseTestCase):
 
         expected_reads = [
             GeneralMeterRead(
-                org_id="my org",
+                org_id="this-utility",
                 device_id="1",
                 account_id="101",
                 location_id=None,
@@ -339,7 +346,7 @@ class TestSentryxAdapter(BaseTestCase):
                 interval_unit=None,
             ),
             GeneralMeterRead(
-                org_id="my org",
+                org_id="this-utility",
                 device_id="2",
                 account_id=None,
                 location_id=None,

--- a/test/fixtures/sentryx-config.yaml
+++ b/test/fixtures/sentryx-config.yaml
@@ -3,6 +3,7 @@ sources:
   org_id: my_utility
   timezone: America/Los_Angeles
   intermediate_output: ./output
+  utility_name: u_name
   sinks:
   - my_snowflake_instance
 


### PR DESCRIPTION
This updates the code to use the configured `org_id` and `org_timezone`. Previously I'd hardcoded those values.