### PR TITLE
Store flowtime with timezone and stop hardcoding org_id in Snowflake

### DIFF
--- a/amiadapters/base.py
+++ b/amiadapters/base.py
@@ -4,6 +4,9 @@ from datetime import datetime
 import json
 from typing import List
 
+from pytz import timezone
+from pytz.tzinfo import DstTzInfo
+
 from amiadapters.storage.base import BaseAMIStorageSink
 
 
@@ -37,10 +40,13 @@ class BaseAMIAdapter(ABC):
         for sink in self.storage_sinks:
             sink.store_transformed()
 
-    def datetime_from_iso_str(self, datetime_str: str, org_timezone: str) -> datetime:
-        # TODO timezones
+    def datetime_from_iso_str(
+        self, datetime_str: str, org_timezone: DstTzInfo
+    ) -> datetime:
         if datetime_str:
             result = datetime.fromisoformat(datetime_str)
+            tz = org_timezone if org_timezone is not None else timezone("UTC")
+            result = result.replace(tzinfo=tz)
         else:
             result = None
         return result

--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -5,7 +5,6 @@ from io import StringIO
 import json
 import logging
 import os
-import pytz
 from pytz.tzinfo import DstTzInfo
 import requests
 import time

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -3,10 +3,8 @@ import json
 from typing import List
 import pytz
 
-import snowflake.connector
-
 from amiadapters.base import GeneralMeter, GeneralMeterRead
-from amiadapters.config import AMIAdapterConfiguration, ConfiguredStorageSink
+from amiadapters.config import ConfiguredStorageSink
 from amiadapters.storage.base import BaseAMIStorageSink
 
 

--- a/test/amiadapters/test_base.py
+++ b/test/amiadapters/test_base.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+
+import pytz
+
+from amiadapters.beacon import Beacon360Adapter
+from test.base_test_case import BaseTestCase
+
+
+class TestBaseAdapter(BaseTestCase):
+
+    def setUp(self):
+        self.adapter = Beacon360Adapter(
+            api_user="user",
+            api_password="pass",
+            intermediate_output="output",
+            use_cache=False,
+            org_id="this-org",
+            org_timezone=pytz.timezone("Europe/Rome"),
+            configured_sinks=[],
+        )
+
+    def test_datetime_from_iso_str__None_results_in_None(self):
+        result = self.adapter.datetime_from_iso_str(None, self.adapter.org_timezone)
+        self.assertIsNone(result)
+
+    def test_datetime_from_iso_str__parses_unaware_dt_and_replaces_tz_without_conversion(
+        self,
+    ):
+        result = self.adapter.datetime_from_iso_str(
+            "2024-08-01 00:54", self.adapter.org_timezone
+        )
+        self.assertEqual(
+            datetime(2024, 8, 1, 0, 54, tzinfo=pytz.timezone("Europe/Rome")), result
+        )
+
+    def test_datetime_from_iso_str__parses_aware_dt_and_replaces_tz_without_conversion(
+        self,
+    ):
+        result = self.adapter.datetime_from_iso_str(
+            "2024-08-01T00:54:00Z", self.adapter.org_timezone
+        )
+        self.assertEqual(
+            datetime(2024, 8, 1, 0, 54, tzinfo=pytz.timezone("Europe/Rome")), result
+        )
+
+    def test_datetime_from_iso_str__parses_aware_dt_and_defaults_to_utc_if_no_tz_provided(
+        self,
+    ):
+        result = self.adapter.datetime_from_iso_str("2024-08-01T00:54:00+02:00", None)
+        self.assertEqual(
+            datetime(2024, 8, 1, 0, 54, tzinfo=pytz.timezone("UTC")), result
+        )
+
+    def test_map_meter_size(self):
+        cases = [
+            ('3/8"', "0.375"),
+            (None, None),
+        ]
+        for size, expected in cases:
+            result = self.adapter.map_meter_size(size)
+            self.assertEqual(result, expected)
+
+    def test_unit_of_measure(self):
+        cases = [
+            ("CF", "CF"),
+            ("CCF", "CCF"),
+            ("Gallon", "Gallon"),
+            (None, None),
+        ]
+        for size, expected in cases:
+            result = self.adapter.map_unit_of_measure(size)
+            self.assertEqual(result, expected)

--- a/test/amiadapters/test_beacon.py
+++ b/test/amiadapters/test_beacon.py
@@ -9,17 +9,12 @@ from amiadapters.beacon import (
     REQUESTED_COLUMNS,
 )
 
-from test.base_test_case import BaseTestCase
-
-
-class MockResponse:
-    def __init__(self, json_data, status_code, text=None):
-        self.json_data = json_data
-        self.status_code = status_code
-        self.text = text
-
-    def json(self):
-        return self.json_data
+from test.base_test_case import (
+    BaseTestCase,
+    MockResponse,
+    mocked_response_429,
+    mocked_response_500,
+)
 
 
 REPORT_CONTENTS_CSV = """\"Account_Billing_Cycle\",\"Account_Email\",\"Account_First_Name\",\"Account_Full_Name\",\"Account_ID\",\"Account_Last_Name\",\"Account_Phone\",\"Account_Portal_Status\",\"Account_Status\",\"Alert_Code\",\"Backflow_Gallons\",\"Battery_Level\",\"Billing_Address_Line1\",\"Billing_Address_Line2\",\"Billing_Address_Line3\",\"Billing_City\",\"Billing_Country\",\"Billing_State\",\"Billing_ZIP\",\"Connector_Type\",\"Current_Leak_Rate\",\"Current_Leak_Start_Date\",\"Demand_Zone_ID\",\"Dials\",\"Endpoint_Install_Date\",\"Endpoint_SN\",\"Endpoint_Status\",\"Endpoint_Type\",\"Estimated_Flag\",\"Flow\",\"Flow_Time\",\"Flow_Unit\",\"High_Read_Limit\",\"Last_Comm_Time\",\"Location_Address_Line1\",\"Location_Address_Line2\",\"Location_Address_Line3\",\"Location_Address_Parity\",\"Location_Area\",\"Location_Bathrooms\",\"Location_Building_Number\",\"Location_Building_Type\",\"Location_City\",\"Location_Continuous_Flow\",\"Location_Country\",\"Location_County_Name\",\"Location_DHS_Code\",\"Location_District\",\"Location_Funding\",\"Location_ID\",\"Location_Irrigated_Area\",\"Location_Irrigation\",\"Location_Latitude\",\"Location_Longitude\",\"Location_Main_Use\",\"Location_Name\",\"Location_Pool\",\"Location_Population\",\"Location_Site\",\"Location_State\",\"Location_Water_Type\",\"Location_Year_Built\",\"Location_ZIP\",\"Low_Read_Limit\",\"Meter_Continuous_Flow\",\"Meter_ID\",\"Meter_Install_Date\",\"Meter_Manufacturer\",\"Meter_Model\",\"Meter_Note\",\"Meter_Size\",\"Meter_Size_Desc\",\"Meter_Size_Unit\",\"Meter_SN\",\"Person_ID\",\"Portal_ID\",\"Raw_Read\",\"Read\",\"Read_Code_1\",\"Read_Code_2\",\"Read_Code_3\",\"Read_Method\",\"Read_Note\",\"Read_Sequence\",\"Read_Time\",\"Read_Unit\",\"Reader_Initials\",\"Register_Note\",\"Register_Number\",\"Register_Resolution\",\"Register_Unit_Of_Measure\",\"SA_Start_Date\",\"Service_Point_Class_Code\",\"Service_Point_Class_Code_Normalized\",\"Service_Point_Cycle\",\"Service_Point_ID\",\"Service_Point_Latitude\",\"Service_Point_Longitude\",\"Service_Point_Route\",\"Service_Point_Timezone\",\"Service_Point_Type\",\"Signal_Strength\",\"Supply_Zone_ID\",\"Trouble_Code\",\"Utility_Use_1\",\"Utility_Use_2\"
@@ -64,15 +59,6 @@ def mocked_get_report_from_link(*args, **kwargs):
 def mocked_exception_from_status_check(*args, **kwargs):
     data = {"state": "exception"}
     return MockResponse(data, 200)
-
-
-def mocked_response_500(*args, **kwargs):
-    return MockResponse({}, 500)
-
-
-def mocked_response_429(*args, **kwargs):
-    data = {"args": [None, None, 3]}
-    return MockResponse(data, 429)
 
 
 def mocked_get_consumption_response_last_page(*args, **kwargs):
@@ -721,7 +707,9 @@ class TestBeacon360Adapter(BaseTestCase):
                 location_id="303022",
                 meter_id="1470158170",
                 endpoint_id="130615549",
-                meter_install_date=datetime.datetime(2016, 1, 1, 23, 59),
+                meter_install_date=datetime.datetime(
+                    2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
                 meter_size="0.625",
                 meter_manufacturer="Sensus",
                 multiplier=None,
@@ -739,7 +727,9 @@ class TestBeacon360Adapter(BaseTestCase):
                 device_id="1470158170",
                 account_id="303022",
                 location_id="303022",
-                flowtime=datetime.datetime(2024, 8, 1, 0, 59),
+                flowtime=datetime.datetime(
+                    2024, 8, 1, 0, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
                 register_value=227.6,
                 register_unit="CCF",
                 interval_value=None,
@@ -750,7 +740,9 @@ class TestBeacon360Adapter(BaseTestCase):
                 device_id="1470158170",
                 account_id="303022",
                 location_id="303022",
-                flowtime=datetime.datetime(2024, 8, 1, 1, 59),
+                flowtime=datetime.datetime(
+                    2024, 8, 1, 1, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
                 register_value=227.6,
                 register_unit="CCF",
                 interval_value=None,
@@ -990,7 +982,9 @@ class TestBeacon360Adapter(BaseTestCase):
                 location_id="303022",
                 meter_id="10101",
                 endpoint_id="130615549",
-                meter_install_date=datetime.datetime(2016, 1, 1, 23, 59),
+                meter_install_date=datetime.datetime(
+                    2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
                 meter_size="0.625",
                 meter_manufacturer="Sensus",
                 multiplier=None,
@@ -1006,7 +1000,9 @@ class TestBeacon360Adapter(BaseTestCase):
                 location_id="303022",
                 meter_id="1470158170",
                 endpoint_id="130615549",
-                meter_install_date=datetime.datetime(2016, 1, 1, 23, 59),
+                meter_install_date=datetime.datetime(
+                    2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
                 meter_size="0.625",
                 meter_manufacturer="Sensus",
                 multiplier=None,
@@ -1024,7 +1020,9 @@ class TestBeacon360Adapter(BaseTestCase):
                 device_id="1470158170",
                 account_id="303022",
                 location_id="303022",
-                flowtime=datetime.datetime(2024, 8, 1, 0, 59),
+                flowtime=datetime.datetime(
+                    2024, 8, 1, 0, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
                 register_value=227.6,
                 register_unit="CCF",
                 interval_value=None,
@@ -1035,7 +1033,9 @@ class TestBeacon360Adapter(BaseTestCase):
                 device_id="10101",
                 account_id="1",
                 location_id="303022",
-                flowtime=datetime.datetime(2024, 8, 1, 1, 59),
+                flowtime=datetime.datetime(
+                    2024, 8, 1, 1, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
                 register_value=227.6,
                 register_unit="CCF",
                 interval_value=None,
@@ -1168,7 +1168,9 @@ class TestBeacon360Adapter(BaseTestCase):
                 location_id="303022",
                 meter_id="1470158170",
                 endpoint_id="130615549",
-                meter_install_date=datetime.datetime(2016, 1, 1, 23, 59),
+                meter_install_date=datetime.datetime(
+                    2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
                 meter_size="0.625",
                 meter_manufacturer="Sensus",
                 multiplier=None,

--- a/test/amiadapters/test_sentryx.py
+++ b/test/amiadapters/test_sentryx.py
@@ -10,16 +10,7 @@ from amiadapters.sentryx import (
     SentryxMeterWithReads,
 )
 
-from test.base_test_case import BaseTestCase
-
-
-class MockResponse:
-    def __init__(self, json_data, status_code):
-        self.json_data = json_data
-        self.status_code = status_code
-
-    def json(self):
-        return self.json_data
+from test.base_test_case import BaseTestCase, MockResponse, mocked_response_500
 
 
 def mocked_get_devices_response_first_page(*args, **kwargs):
@@ -93,10 +84,6 @@ def mocked_get_devices_response_first_page(*args, **kwargs):
 def mocked_get_devices_response_last_page(*args, **kwargs):
     data = {"meters": [], "currentPage": 2, "itemsOnPage": 0, "totalCount": 1}
     return MockResponse(data, 200)
-
-
-def mocked_response_500(*args, **kwargs):
-    return MockResponse({}, 500)
 
 
 def mocked_get_consumption_response_first_page(*args, **kwargs):
@@ -323,7 +310,9 @@ class TestSentryxAdapter(BaseTestCase):
                 location_id=None,
                 meter_id="1",
                 endpoint_id=None,
-                meter_install_date=datetime.datetime(2022, 2, 8, 22, 10, 43),
+                meter_install_date=datetime.datetime(
+                    2022, 2, 8, 22, 10, 43, tzinfo=pytz.timezone("Africa/Algiers")
+                ),
                 meter_size="0.375",
                 meter_manufacturer="manufacturer",
                 multiplier=None,
@@ -340,7 +329,9 @@ class TestSentryxAdapter(BaseTestCase):
                 device_id="1",
                 account_id="101",
                 location_id=None,
-                flowtime=datetime.datetime(2024, 7, 7, 1, 0),
+                flowtime=datetime.datetime(
+                    2024, 7, 7, 1, 0, tzinfo=pytz.timezone("Africa/Algiers")
+                ),
                 register_value=116233.61,
                 register_unit="CF",
                 interval_value=None,
@@ -351,7 +342,9 @@ class TestSentryxAdapter(BaseTestCase):
                 device_id="2",
                 account_id=None,
                 location_id=None,
-                flowtime=datetime.datetime(2024, 7, 7, 1, 0),
+                flowtime=datetime.datetime(
+                    2024, 7, 7, 1, 0, tzinfo=pytz.timezone("Africa/Algiers")
+                ),
                 register_value=11,
                 register_unit="CF",
                 interval_value=None,

--- a/test/base_test_case.py
+++ b/test/base_test_case.py
@@ -16,3 +16,26 @@ class BaseTestCase(unittest.TestCase):
     def get_fixture_path(cls, filename):
         fixture_path = cls.FIXTURE_DIR / filename
         return fixture_path.resolve()
+
+
+class MockResponse:
+    """
+    Mock HTTP response, e.g. from requests.get()
+    """
+
+    def __init__(self, json_data, status_code, text=None):
+        self.json_data = json_data
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self.json_data
+
+
+def mocked_response_500(*args, **kwargs):
+    return MockResponse({}, 500)
+
+
+def mocked_response_429(*args, **kwargs):
+    data = {"args": [None, None, 3]}
+    return MockResponse(data, 429)


### PR DESCRIPTION
Two small fixes:
- Store flowtime using the org's configured timezone
- Store the org's configured org_id in Snowflake (previously was hardcoded, just tweaked the code to use the real value)

Also added and cleaned up some tests.