### PR TITLE
Bump EC2 size; Create DAG schedules; Ensure DAG tasks run sequentially

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ export AMI_CONNECT__AIRFLOW_SERVER_HOSTNAME=<my EC2 hostname> && sh deploy.sh
 We use Apache Airflow to orchestrate our data pipeline. The Airflow code is in the `amicontrol` package.
 
 With the dependencies from `requirements.txt` installed, you should be able to run Airflow locally. First,
-set the AIRFLOW_HOME variable:
+set the AIRFLOW_HOME variable and your PYTHONPATH:
 
 ```
 mkdir ./amicontrol/airflow
 export AIRFLOW_HOME=`pwd`/amicontrol/airflow
+export PYTHONPATH="${PYTHONPATH}:./amiadapters"
 ```
 
 If it's your first time running the application on your machine, initialize the local Airflow app in `AIRFLOW_HOME` with:
@@ -94,9 +95,6 @@ load_examples = False
 
 Before you run `airflow standalone`, set these environment variables:
 ```
-# This allows the DAG to import code from this project's other Python packages
-export PYTHONPATH="${PYTHONPATH}:./amiadapters"
-
 # This fixes hanging HTTP requests
 # See: https://stackoverflow.com/questions/75980623/why-is-my-airflow-hanging-up-if-i-send-a-http-request-inside-a-task
 export NO_PROXY="*"

--- a/amiadapters/base.py
+++ b/amiadapters/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import dataclasses
 from datetime import datetime, timedelta
 import json
-from typing import List
+from typing import List, Tuple
 
 from pytz import timezone
 from pytz.tzinfo import DstTzInfo
@@ -36,6 +36,10 @@ class BaseAMIAdapter(ABC):
 
     @abstractmethod
     def transform(self):
+        pass
+
+    @abstractmethod
+    def calculate_backfill_range(self) -> Tuple[datetime, datetime]:
         pass
 
     def load_raw(self):

--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -573,6 +573,16 @@ class Beacon360Adapter(BaseAMIAdapter):
     def _transformed_reads_output_file(self) -> str:
         return os.path.join(self.output_folder, f"{self.name()}-transformed-reads.txt")
 
+    def calculate_backfill_range(self) -> Tuple[datetime, datetime]:
+        snowflake_sink = [s for s in self.storage_sinks if isinstance(s, BeaconSnowflakeStorageSink)]
+        if not snowflake_sink:
+            now = datetime.now()
+            return now - timedelta(days=2), now
+        else:
+            sink = snowflake_sink[0]
+            oldest = sink.get_oldest_meter_read_time(self.org_id)
+            return oldest - timedelta(days=2), oldest
+
 
 class BeaconSnowflakeStorageSink(SnowflakeStorageSink):
     """

--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -574,7 +574,9 @@ class Beacon360Adapter(BaseAMIAdapter):
         return os.path.join(self.output_folder, f"{self.name()}-transformed-reads.txt")
 
     def calculate_backfill_range(self) -> Tuple[datetime, datetime]:
-        snowflake_sink = [s for s in self.storage_sinks if isinstance(s, BeaconSnowflakeStorageSink)]
+        snowflake_sink = [
+            s for s in self.storage_sinks if isinstance(s, BeaconSnowflakeStorageSink)
+        ]
         if not snowflake_sink:
             now = datetime.now()
             return now - timedelta(days=2), now

--- a/amiadapters/run.py
+++ b/amiadapters/run.py
@@ -24,6 +24,7 @@ def run_pipeline(
         )
 
     for adapter in adapters:
+        extract_range_start, extract_range_end = adapter.calculate_backfill_range()
         logger.info(f"Extracting data for {adapter.name()}")
         adapter.extract(extract_range_start, extract_range_end)
         logger.info(f"Extracted data for {adapter.name()} to {adapter.output_folder}")

--- a/amiadapters/sentryx.py
+++ b/amiadapters/sentryx.py
@@ -368,6 +368,9 @@ class SentryxAdapter(BaseAMIAdapter):
 
         return list(meters_by_id.values()), meter_reads
 
+    def calculate_backfill_range(self) -> Tuple[datetime, datetime]:
+        raise Exception("Not implemented")
+
     def _raw_meter_output_file(self) -> str:
         return os.path.join(self.output_folder, f"{self.name()}-raw-meters.txt")
 

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 from typing import List
 import pytz
@@ -180,3 +180,16 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
             read.interval_unit,
         ]
         return tuple(result)
+
+    def get_oldest_meter_read_time(self, org_id) -> datetime:
+        conn = self.sink_config.connection()
+
+        query = """
+        SELECT MIN(flowtime) FROM readings
+        WHERE org_id = ?
+        """
+        result = conn.cursor().execute(query, (org_id,))
+        rows = [i for i in result]
+        if len(rows) != 1:
+            return datetime.now()
+        return rows[0][0]

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -4,84 +4,109 @@ import pathlib
 
 from airflow.decorators import dag, task
 from airflow.models.param import Param
-from airflow.operators.python import get_current_context
 
 from amiadapters.base import BaseAMIAdapter, default_date_range
 from amiadapters.config import AMIAdapterConfiguration
 
 
-@dag(
-    schedule=None,
-    params={
-        "extract_range_start": Param(
-            type="string",
-            description="Start of date range for which we'll extract meter read data",
-            default=None,
-        ),
-        "extract_range_end": Param(
-            type="string",
-            description="End of date range for which we'll extract meter read data",
-            default=None,
-        ),
-    },
-    catchup=False,
-    tags=["ami"],
-)
-def ami_control_dag():
+def ami_control_dag_factory(dag_id, schedule, params, is_backfill=False):
+    """
+    Factory for AMI control meter read DAGs that run on different schedules:
+    - The regular run, which refreshes recent data
+    - The backfill run, which runs more frequently and attempts to backfill data
+    """
+    @dag(
+        dag_id=dag_id,
+        schedule=schedule,
+        params=params,
+        catchup=False,
+        start_date=datetime(2024, 1, 1),
+        tags=["ami"],
+    )
+    def ami_control_dag():
 
-    @task()
-    def extract(adapter: BaseAMIAdapter, **context):
-        start, end = (
-            context["params"]["extract_range_start"],
-            context["params"]["extract_range_end"],
+        @task()
+        def extract(adapter: BaseAMIAdapter, **context):
+            if is_backfill:
+                start, end = adapter.calculate_backfill_range()
+            else:
+                start, end = (
+                    context["params"].get("extract_range_start"),
+                    context["params"].get("extract_range_end"),
+                )
+
+                if isinstance(start, str):
+                    start = datetime.fromisoformat(start)
+                if isinstance(end, str):
+                    end = datetime.fromisoformat(end)
+
+                if start is None or end is None:
+                    start, end = default_date_range(start, end)
+
+            adapter.extract(start, end)
+
+        @task()
+        def transform(adapter: BaseAMIAdapter):
+            adapter.transform()
+
+        @task()
+        def load_raw(adapter: BaseAMIAdapter):
+            adapter.load_raw()
+
+        @task()
+        def load_transformed(adapter: BaseAMIAdapter):
+            adapter.load_transformed()
+
+        @task()
+        def final_task():
+            # Placeholder to gather results of parallel tasks in DAG
+            return
+
+        config = AMIAdapterConfiguration.from_yaml(
+            os.environ.get(
+                "AMI_CONFIG_YAML",
+                pathlib.Path(__file__).joinpath("..", "..", "config.yaml").resolve(),
+            ),
+            os.environ.get(
+                "AMI_SECRET_YAML",
+                pathlib.Path(__file__).joinpath("..", "..", "secrets.yaml").resolve(),
+            ),
         )
 
-        if isinstance(start, str):
-            start = datetime.fromisoformat(start)
-        if isinstance(end, str):
-            end = datetime.fromisoformat(end)
+        adapters = config.adapters()
 
-        if start is None or end is None:
-            start, end = default_date_range(start, end)
+        for adapter in adapters:
+            # Set sequence of tasks for this utility
+            extract.override(task_id=f"extract-{adapter.name()}")(adapter) >> \
+            transform.override(task_id=f"transform-{adapter.name()}")(adapter) >> \
+            [
+                # Run load tasks in parallel
+                load_raw.override(task_id=f"load-raw-{adapter.name()}")(adapter),
+                load_transformed.override(task_id=f"load-transformed-{adapter.name()}")(adapter)
+            ] >> \
+            final_task.override(task_id=f"finish-{adapter.name()}")()
 
-        adapter.extract(start, end)
 
-    @task()
-    def transform(adapter: BaseAMIAdapter):
-        adapter.transform()
+    ami_control_dag()
 
-    @task()
-    def load_raw(adapter: BaseAMIAdapter):
-        adapter.load_raw()
 
-    @task()
-    def load_transformed(adapter: BaseAMIAdapter):
-        adapter.load_transformed()
-
-    config = AMIAdapterConfiguration.from_yaml(
-        os.environ.get(
-            "AMI_CONFIG_YAML",
-            pathlib.Path(__file__).joinpath("..", "..", "config.yaml").resolve(),
-        ),
-        os.environ.get(
-            "AMI_SECRET_YAML",
-            pathlib.Path(__file__).joinpath("..", "..", "secrets.yaml").resolve(),
-        ),
+# Manual runs
+standard_params = {
+    "extract_range_start": Param(
+        type="string",
+        description="Start of date range for which we'll extract meter read data",
+        default="",
+    ),
+    "extract_range_end": Param(
+        type="string",
+        description="End of date range for which we'll extract meter read data",
+        default="",
     )
+}
+ami_control_dag_factory("ami-meter-read-dag-manual", None, standard_params)
 
-    adapters = config.adapters()
+# Standard run that fetches most recent meter read data
+ami_control_dag_factory("ami-meter-read-dag-standard", "0 12 * * *", {})
 
-    for adapter in adapters:
-        extract.override(task_id=f"extract-{adapter.name()}")(adapter)
-
-    for adapter in adapters:
-        transform.override(task_id=f"transform-{adapter.name()}")(adapter)
-
-    for adapter in adapters:
-        load_raw.override(task_id=f"load-raw-{adapter.name()}")(adapter)
-
-    for adapter in adapters:
-        load_transformed.override(task_id=f"load-transformed-{adapter.name()}")(adapter)
-
-
-ami_control_dag()
+# Backfill run
+ami_control_dag_factory("ami-meter-read-dag-backfill", "45 * * * *", {}, is_backfill=True)

--- a/amideploy/infrastructure/main.tf
+++ b/amideploy/infrastructure/main.tf
@@ -37,7 +37,7 @@ output "airflow_server_private_key_pem" {
 
 resource "aws_instance" "ami_connect_airflow_server" {
   ami           = "ami-087f352c165340ea1"
-  instance_type = "t3.medium"
+  instance_type = "t3.xlarge"
   vpc_security_group_ids = [aws_security_group.airflow_server_sg.id]
   key_name      = aws_key_pair.generated_airflow_server_key.key_name
 


### PR DESCRIPTION
A few updates here:
- Bumps the EC2 size so we have 16GB of memory (we were running out of memory when the instance had 4GB)
- We now have 3 DAGs, each a version of the previous DAG: manual, daily refresh, backfill. The backfill run grabs the oldest meter read date in the database and tries to fetch the previous couple days' data. Not a bulletproof strategy, but a start.
- Updates DAG so that a utility's ETL tasks run in sequence and fail together