### PR TITLE
Fix error in transform step when meter_id is None

### DIFF
--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -551,10 +551,7 @@ class Beacon360Adapter(BaseAMIAdapter):
             )
             transformed_reads.append(read)
 
-        # Sort for deterministic unit tests. If this becomes a performance issue, we may be able to revisit.
-        meters_sorted = list(sorted(transformed_meters, key=lambda m: m.meter_id))
-
-        return meters_sorted, transformed_reads
+        return transformed_meters, transformed_reads
 
     def _cached_report_file(
         self, extract_range_start: datetime, extract_range_end: datetime

--- a/test/amiadapters/test_beacon.py
+++ b/test/amiadapters/test_beacon.py
@@ -713,6 +713,7 @@ class TestBeacon360Adapter(BaseTestCase):
         transformed_meters, transformed_reads = (
             self.adapter._transform_meters_and_reads(raw_meters_with_reads)
         )
+        transformed_meters = list(sorted(transformed_meters, key=lambda m: m.meter_id))
 
         expected_meters = [
             GeneralMeter(
@@ -988,6 +989,7 @@ class TestBeacon360Adapter(BaseTestCase):
         transformed_meters, transformed_reads = (
             self.adapter._transform_meters_and_reads(raw_meters_with_reads)
         )
+        transformed_meters = list(sorted(transformed_meters, key=lambda m: m.meter_id))
 
         expected_meters = [
             GeneralMeter(
@@ -1174,6 +1176,7 @@ class TestBeacon360Adapter(BaseTestCase):
         transformed_meters, transformed_reads = (
             self.adapter._transform_meters_and_reads(raw_meters_with_reads)
         )
+        transformed_meters = list(sorted(transformed_meters, key=lambda m: m.meter_id))
 
         expected_meters = [
             GeneralMeter(


### PR DESCRIPTION
Transforms for beacon data were failing when a meter didn't have a value for `meter_id`. This PR removes an unnecessary sort where the error cropped up - we were sorting only for clean unit tests.

Error:
```
  File "/home/ec2-user/amiadapters/beacon.py", line 555, in _transform_meters_and_reads
    meters_sorted = list(sorted(transformed_meters, key=lambda m: m.meter_id))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

We should arguably skip the meter if it doesn't have a `meter_id` (and `device_id`), but I thought that it might have valid read data so I haven't filtered the record out here.