### PR TITLE
Clean old cache files

### DIFF
--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -551,10 +551,7 @@ class Beacon360Adapter(BaseAMIAdapter):
             )
             transformed_reads.append(read)
 
-        # Sort for deterministic unit tests. If this becomes a performance issue, we may be able to revisit.
-        meters_sorted = list(sorted(transformed_meters, key=lambda m: m.meter_id))
-
-        return meters_sorted, transformed_reads
+        return transformed_meters, transformed_reads
 
     def _cached_report_file(
         self, extract_range_start: datetime, extract_range_end: datetime

--- a/test/amiadapters/test_beacon.py
+++ b/test/amiadapters/test_beacon.py
@@ -713,6 +713,7 @@ class TestBeacon360Adapter(BaseTestCase):
         transformed_meters, transformed_reads = (
             self.adapter._transform_meters_and_reads(raw_meters_with_reads)
         )
+        transformed_meters = list(sorted(transformed_meters, key=lambda m: m.meter_id))
 
         expected_meters = [
             GeneralMeter(
@@ -988,6 +989,7 @@ class TestBeacon360Adapter(BaseTestCase):
         transformed_meters, transformed_reads = (
             self.adapter._transform_meters_and_reads(raw_meters_with_reads)
         )
+        transformed_meters = list(sorted(transformed_meters, key=lambda m: m.meter_id))
 
         expected_meters = [
             GeneralMeter(
@@ -1174,6 +1176,7 @@ class TestBeacon360Adapter(BaseTestCase):
         transformed_meters, transformed_reads = (
             self.adapter._transform_meters_and_reads(raw_meters_with_reads)
         )
+        transformed_meters = list(sorted(transformed_meters, key=lambda m: m.meter_id))
 
         expected_meters = [
             GeneralMeter(


### PR DESCRIPTION
This deletes old cached beacon API data files so we don't fill up the disk (which happened over the weekend). This is a quick and dirty approach. The cache is really just for local development so you don't have to wait on the long Beacon 360 polls. If we want to make it smarter later, we can.