### PR TITLE
Fix memory issue on extract

### DIFF
--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -473,10 +473,6 @@ class Beacon360Adapter(BaseAMIAdapter):
 
         Assumes Beacon360MeterAndRead attribute names are identical to CSV column names.
         """
-        report_csv_rows = report.strip().split("\n")
-        if not report_csv_rows:
-            return
-
         csv_reader = csv.DictReader(StringIO(report), delimiter=",")
         meter_with_reads = []
         for data in csv_reader:

--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -292,7 +292,9 @@ class Beacon360Adapter(BaseAMIAdapter):
 
     def extract(self, extract_range_start: datetime, extract_range_end: datetime):
         report = self._fetch_range_report(extract_range_start, extract_range_end)
+        logger.info("Fetched report")
         meter_with_reads = self._parse_raw_range_report(report)
+        logger.info(f"Parsed {len(meter_with_reads)} records from report")
         with open(self._raw_reads_output_file(), "w") as f:
             content = "\n".join(
                 json.dumps(m, cls=DataclassJSONEncoder) for m in meter_with_reads


### PR DESCRIPTION
A backfill run scheduled when it ran out of memory last night: http://www.cadc-ami-connect.com/dags/ami-meter-read-dag-backfill/grid?dag_run_id=scheduled__2025-04-29T10%3A45%3A00%2B00%3A00&tab=logs&task_id=extract-beacon-360-cadc_thousand_oaks

It failed in the Extract task after it wrote the report data to the cache file. I found this variable that was unused (my mistake) that might have caused the entire report to be stored an extra time in memory. The reports are sometimes 500mb, so that's not nothing. Deleting the unused variable to see if it helps.