### PR TITLE
Use run_id from DAG to partition temporary output files

### DIFF
--- a/amiadapters/outputs/local.py
+++ b/amiadapters/outputs/local.py
@@ -18,31 +18,29 @@ class LocalTaskOutputController(BaseTaskOutputController):
     EXTRACT = "e"
     TRANSFORM = "t"
 
-    def __init__(self, output_folder: str, run_id: str, org_id: str):
+    def __init__(self, output_folder: str, org_id: str):
         """
         output_folder: directory in filesystem where outputs should be stored
-        run_id: something that uniquely identifies this run of the pipeline
         org_id: org for which this data was extracted
         """
-        if not output_folder or not run_id or not org_id:
+        if not output_folder or not org_id:
             raise Exception(
-                f"Missing required parameter. output_folder:{output_folder} run_id:{run_id}, org_id:{org_id}"
+                f"Missing required parameter. output_folder:{output_folder} org_id:{org_id}"
             )
         self.output_folder = output_folder
-        self.run_id = run_id
         self.org_id = org_id
 
-    def write_extract_outputs(self, outputs: ExtractOutput):
+    def write_extract_outputs(self, run_id: str, outputs: ExtractOutput):
         for name, content in outputs.get_outputs().items():
-            path = os.path.join(self._base_dir(), self.EXTRACT, name)
+            path = os.path.join(self._base_dir(run_id), self.EXTRACT, name)
             self._create_parent_directories_if_missing(path)
             logger.info(f"Writing extract output to {path}")
             with open(path, "w") as f:
                 f.write(content)
             logger.info(f"Wrote extract output to {path}")
 
-    def read_extract_outputs(self) -> ExtractOutput:
-        path = os.path.join(self._base_dir(), self.EXTRACT)
+    def read_extract_outputs(self, run_id: str) -> ExtractOutput:
+        path = os.path.join(self._base_dir(run_id), self.EXTRACT)
         outputs = {}
         for name in os.listdir(path):
             logger.info(f"Reading extract output at {name}")
@@ -52,8 +50,8 @@ class LocalTaskOutputController(BaseTaskOutputController):
             logger.info(f"Finished reading extract output at {name}")
         return ExtractOutput(outputs)
 
-    def write_transformed_meters(self, meters: List[GeneralMeter]):
-        path = self._transformed_meters_path()
+    def write_transformed_meters(self, run_id: str, meters: List[GeneralMeter]):
+        path = self._transformed_meters_path(run_id)
         self._create_parent_directories_if_missing(path)
         logger.info(f"Writing {len(meters)} transformed meters to {path}")
         with open(path, "w") as f:
@@ -62,8 +60,8 @@ class LocalTaskOutputController(BaseTaskOutputController):
             )
         logger.info(f"Wrote meters to {path}")
 
-    def read_transformed_meters(self) -> List[GeneralMeter]:
-        path = self._transformed_meters_path()
+    def read_transformed_meters(self, run_id: str) -> List[GeneralMeter]:
+        path = self._transformed_meters_path(run_id)
         logger.info(f"Reading meters from {path}")
         with open(path, "r") as f:
             text = f.read()
@@ -71,8 +69,8 @@ class LocalTaskOutputController(BaseTaskOutputController):
         logger.info(f"Read {len(meters)} meters from {path}")
         return meters
 
-    def write_transformed_meter_reads(self, reads: List[GeneralMeterRead]):
-        path = self._transformed_reads_path()
+    def write_transformed_meter_reads(self, run_id: str, reads: List[GeneralMeterRead]):
+        path = self._transformed_reads_path(run_id)
         self._create_parent_directories_if_missing(path)
         logger.info(f"Writing {len(reads)} transformed meters to {path}")
         with open(path, "w") as f:
@@ -81,8 +79,8 @@ class LocalTaskOutputController(BaseTaskOutputController):
             )
         logger.info(f"Wrote reads to {path}")
 
-    def read_transformed_meter_reads(self) -> List[GeneralMeterRead]:
-        path = self._transformed_reads_path()
+    def read_transformed_meter_reads(self, run_id: str) -> List[GeneralMeterRead]:
+        path = self._transformed_reads_path(run_id)
         logger.info(f"Reading meter reads from {path}")
         with open(path, "r") as f:
             text = f.read()
@@ -92,14 +90,14 @@ class LocalTaskOutputController(BaseTaskOutputController):
         logger.info(f"Read {len(reads)} meter reads from {path}")
         return reads
 
-    def _base_dir(self) -> str:
-        return os.path.join(self.output_folder, self.run_id, self.org_id)
+    def _base_dir(self, run_id: str) -> str:
+        return os.path.join(self.output_folder, run_id, self.org_id)
 
-    def _transformed_meters_path(self) -> str:
-        return os.path.join(self._base_dir(), self.TRANSFORM, "meters.json")
+    def _transformed_meters_path(self, run_id: str) -> str:
+        return os.path.join(self._base_dir(run_id), self.TRANSFORM, "meters.json")
 
-    def _transformed_reads_path(self) -> str:
-        return os.path.join(self._base_dir(), self.TRANSFORM, "reads.json")
+    def _transformed_reads_path(self, run_id: str) -> str:
+        return os.path.join(self._base_dir(run_id), self.TRANSFORM, "reads.json")
 
     def _create_parent_directories_if_missing(self, path):
         directory = os.path.dirname(path)

--- a/amiadapters/run.py
+++ b/amiadapters/run.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 
 from amiadapters.base import default_date_range
@@ -17,6 +18,7 @@ def run_pipeline(
     """
     config = AMIAdapterConfiguration.from_yaml(config_yaml, secrets_yaml)
     adapters = config.adapters()
+    run_id = f"run-{datetime.now().isoformat()}"
 
     if extract_range_start is None or extract_range_end is None:
         extract_range_start, extract_range_end = default_date_range(
@@ -24,9 +26,8 @@ def run_pipeline(
         )
 
     for adapter in adapters:
-        extract_range_start, extract_range_end = adapter.calculate_backfill_range()
         logger.info(f"Extracting data for {adapter.name()}")
-        adapter.extract(extract_range_start, extract_range_end)
+        adapter.extract(run_id, extract_range_start, extract_range_end)
         logger.info(f"Extracted data for {adapter.name()} to {adapter.output_folder}")
 
     logger.info(f"Extracted data for {len(adapters)} adapters")
@@ -35,7 +36,7 @@ def run_pipeline(
         logger.info(
             f"Transforming data for {adapter.name()} from {adapter.output_folder}"
         )
-        adapter.transform()
+        adapter.transform(run_id)
         logger.info(f"Transformed data for {adapter.name()} to {adapter.output_folder}")
 
     logger.info(f"Transformed data for {len(adapters)} adapters")
@@ -44,7 +45,7 @@ def run_pipeline(
         logger.info(
             f"Loading raw data for {adapter.name()} from {adapter.output_folder}"
         )
-        adapter.load_raw()
+        adapter.load_raw(run_id)
         logger.info(
             f"Loaded raw data for {adapter.name()} from {adapter.output_folder}"
         )
@@ -55,7 +56,7 @@ def run_pipeline(
         logger.info(
             f"Loading transformed data for {adapter.name()} from {adapter.output_folder}"
         )
-        adapter.load_transformed()
+        adapter.load_transformed(run_id)
         logger.info(
             f"Loaded transformed data for {adapter.name()} from {adapter.output_folder}"
         )

--- a/amiadapters/storage/base.py
+++ b/amiadapters/storage/base.py
@@ -15,9 +15,9 @@ class BaseAMIStorageSink(ABC):
         self.sink_config = sink_config
 
     @abstractmethod
-    def store_raw(self):
+    def store_raw(self, run_id: str):
         pass
 
     @abstractmethod
-    def store_transformed(self):
+    def store_transformed(self, run_id: str):
         pass

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -22,9 +22,9 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
     ):
         super().__init__(output_controller, sink_config)
 
-    def store_transformed(self):
-        meters = self.output_controller.read_transformed_meters()
-        reads = self.output_controller.read_transformed_meter_reads()
+    def store_transformed(self, run_id):
+        meters = self.output_controller.read_transformed_meters(run_id)
+        reads = self.output_controller.read_transformed_meter_reads(run_id)
 
         conn = self.sink_config.connection()
 

--- a/test/amiadapters/outputs/test_local.py
+++ b/test/amiadapters/outputs/test_local.py
@@ -15,7 +15,7 @@ class TestLocalTaskOutputController(BaseTestCase):
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
         self.controller = LocalTaskOutputController(
-            output_folder=self.test_dir, run_id="run123", org_id="org456"
+            output_folder=self.test_dir, org_id="org456"
         )
 
     def tearDown(self):
@@ -24,7 +24,7 @@ class TestLocalTaskOutputController(BaseTestCase):
     def test_write_and_read_extract_outputs(self):
         data = {"file1.txt": "hello world", "file2.txt": "more data"}
         extract_output = ExtractOutput(data)
-        self.controller.write_extract_outputs(extract_output)
+        self.controller.write_extract_outputs("run123", extract_output)
 
         for filename, content in data.items():
             path = os.path.join(self.test_dir, "run123/org456/e", filename)
@@ -32,7 +32,7 @@ class TestLocalTaskOutputController(BaseTestCase):
             with open(path, "r") as f:
                 self.assertEqual(f.read(), content)
 
-        result = self.controller.read_extract_outputs()
+        result = self.controller.read_extract_outputs("run123")
         self.assertEqual(data, result.get_outputs())
         self.assertEqual("hello world", result.from_file("file1.txt"))
 
@@ -75,7 +75,7 @@ class TestLocalTaskOutputController(BaseTestCase):
                 location_zip="93727",
             ),
         ]
-        self.controller.write_transformed_meters(meters)
+        self.controller.write_transformed_meters("run123", meters)
 
         path = os.path.join(self.test_dir, "run123/org456/t/meters.json")
         self.assertTrue(os.path.exists(path))
@@ -84,7 +84,7 @@ class TestLocalTaskOutputController(BaseTestCase):
             lines = f.read().strip().split("\n")
             self.assertEqual(len(lines), 2)
 
-        meters_out = self.controller.read_transformed_meters()
+        meters_out = self.controller.read_transformed_meters("run123")
         self.assertEqual(len(meters_out), 2)
         self.assertEqual(meters_out[0].device_id, "1")
         self.assertEqual(meters_out[1].device_id, "2")
@@ -118,12 +118,12 @@ class TestLocalTaskOutputController(BaseTestCase):
                 interval_unit=None,
             ),
         ]
-        self.controller.write_transformed_meter_reads(reads)
+        self.controller.write_transformed_meter_reads("run123", reads)
 
         path = os.path.join(self.test_dir, "run123/org456/t/reads.json")
         self.assertTrue(os.path.exists(path))
 
-        reads_out = self.controller.read_transformed_meter_reads()
+        reads_out = self.controller.read_transformed_meter_reads("run123")
         self.assertEqual(len(reads_out), 2)
         self.assertEqual(reads_out[0].device_id, "1")
         self.assertEqual(reads_out[0].register_value, 123.4)


### PR DESCRIPTION
Uses DAG run's run_id to partition the temporary output files (i.e. splits them into folders per run).