### PR TITLE
Create S3 and roles in terraform, store intermediate files in s3

### DIFF
--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -18,6 +18,7 @@ from amiadapters.models import GeneralMeter, GeneralMeterRead
 from amiadapters.config import ConfiguredStorageSink, ConfiguredStorageSinkType
 from amiadapters.outputs.base import BaseTaskOutputController, ExtractOutput
 from amiadapters.outputs.local import LocalTaskOutputController
+from amiadapters.outputs.s3 import S3TaskOutputController
 from amiadapters.storage.snowflake import SnowflakeStorageSink
 
 logger = logging.getLogger(__name__)
@@ -272,8 +273,12 @@ class Beacon360Adapter(BaseAMIAdapter):
         self.use_cache = use_cache
         self.org_id = org_id
         self.org_timezone = org_timezone
-        self.output_controller = LocalTaskOutputController(
-            self.output_folder, self.org_id
+        # self.output_controller = LocalTaskOutputController(
+        #     self.output_folder, self.org_id
+        # )
+        self.output_controller = S3TaskOutputController(
+            "cadc-ami-connect",
+            self.org_id,
         )
         storage_sinks = []
         for sink in configured_sinks:

--- a/amiadapters/outputs/s3.py
+++ b/amiadapters/outputs/s3.py
@@ -1,0 +1,105 @@
+import json
+import logging
+import os
+from typing import List
+
+import boto3
+from botocore.exceptions import ClientError
+
+from amiadapters.models import GeneralMeter, GeneralMeterRead
+from amiadapters.base import GeneralModelJSONEncoder
+from amiadapters.outputs.base import BaseTaskOutputController, ExtractOutput
+
+logger = logging.getLogger(__name__)
+
+
+class S3TaskOutputController(BaseTaskOutputController):
+    """
+    Uses Amazon S3 for intermediate task outputs.
+    """
+
+    EXTRACT = "e"
+    TRANSFORM = "t"
+
+    def __init__(
+        self, bucket_name: str, org_id: str, s3_prefix: str = "intermediate_outputs"
+    ):
+        """
+        bucket_name: S3 bucket to use
+        org_id: identifier for the organization
+        s3_prefix: optional S3 prefix (acts like a root folder inside the bucket)
+        """
+        if not bucket_name or not org_id:
+            raise Exception(
+                f"Missing required parameter. bucket_name:{bucket_name} org_id:{org_id}"
+            )
+
+        self.bucket_name = bucket_name
+        self.org_id = org_id
+        self.s3_prefix = s3_prefix.strip("/")
+        self.s3 = boto3.client("s3")
+
+    def write_extract_outputs(self, run_id: str, outputs: ExtractOutput):
+        for name, content in outputs.get_outputs().items():
+            key = self._s3_key(run_id, self.EXTRACT, name)
+            logger.info(f"Uploading extract output to s3://{self.bucket_name}/{key}")
+            self._upload_string_to_s3(key, content)
+
+    def read_extract_outputs(self, run_id: str) -> ExtractOutput:
+        prefix = self._s3_key(run_id, self.EXTRACT, "")
+        outputs = {}
+        logger.info(f"Reading extract outputs from s3://{self.bucket_name}/{prefix}")
+        response = self.s3.list_objects_v2(Bucket=self.bucket_name, Prefix=prefix)
+        for obj in response.get("Contents", []):
+            key = obj["Key"]
+            name = os.path.basename(key)
+            content = self._download_string_from_s3(key)
+            outputs[name] = content
+        return ExtractOutput(outputs)
+
+    def write_transformed_meters(self, run_id: str, meters: List[GeneralMeter]):
+        key = self._s3_key(run_id, self.TRANSFORM, "meters.json")
+        logger.info(f"Uploading {len(meters)} meters to s3://{self.bucket_name}/{key}")
+        data = "\n".join(json.dumps(m, cls=GeneralModelJSONEncoder) for m in meters)
+        self._upload_string_to_s3(key, data)
+
+    def read_transformed_meters(self, run_id: str) -> List[GeneralMeter]:
+        key = self._s3_key(run_id, self.TRANSFORM, "meters.json")
+        logger.info(f"Downloading meters from s3://{self.bucket_name}/{key}")
+        text = self._download_string_from_s3(key)
+        return [GeneralMeter(**json.loads(line)) for line in text.strip().split("\n")]
+
+    def write_transformed_meter_reads(self, run_id: str, reads: List[GeneralMeterRead]):
+        key = self._s3_key(run_id, self.TRANSFORM, "reads.json")
+        logger.info(f"Uploading {len(reads)} reads to s3://{self.bucket_name}/{key}")
+        data = "\n".join(json.dumps(r, cls=GeneralModelJSONEncoder) for r in reads)
+        self._upload_string_to_s3(key, data)
+
+    def read_transformed_meter_reads(self, run_id: str) -> List[GeneralMeterRead]:
+        key = self._s3_key(run_id, self.TRANSFORM, "reads.json")
+        logger.info(f"Downloading reads from s3://{self.bucket_name}/{key}")
+        text = self._download_string_from_s3(key)
+        return [
+            GeneralMeterRead(**json.loads(line)) for line in text.strip().split("\n")
+        ]
+
+    def _s3_key(self, run_id: str, stage: str, name: str) -> str:
+        parts = [self.s3_prefix, run_id, self.org_id, stage, name]
+        return "/".join(part.strip("/") for part in parts if part)
+
+    def _upload_string_to_s3(self, key: str, content: str):
+        try:
+            self.s3.put_object(
+                Bucket=self.bucket_name, Key=key, Body=content.encode("utf-8")
+            )
+        except ClientError as e:
+            logger.error(f"Failed to upload to S3 at {key}: {e}")
+            raise
+
+    def _download_string_from_s3(self, key: str) -> str:
+        try:
+            response = self.s3.get_object(Bucket=self.bucket_name, Key=key)
+            return response["Body"].read().decode("utf-8")
+        except ClientError as e:
+            logger.error(f"Failed to download from S3 at {key}: {e}")
+            raise

--- a/amideploy/infrastructure/variables.tf
+++ b/amideploy/infrastructure/variables.tf
@@ -25,6 +25,11 @@ variable "ssh_ip_allowlist" {
   type        = list(string)
 }
 
+variable "ami_connect_s3_bucket_name" {
+  description = "Name for S3 bucket used for intermediate task outputs. Must be a globally unique name, so include your org name, e.g. my-company-ami-connect-bucket."
+  type        = string
+}
+
 variable "ami_connect_tag" {
   description = "AWS tag used on all resources for this project."
   type        = string

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ requests==2.32.3
 urllib3==2.3.0
 black==25.1.0
 PyYAML==6.0.2
+boto3==1.38.5
 # Installs with constraints for Python 3.12
 apache-airflow==2.10.5 --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.12.txt
 apache-airflow-providers-snowflake==6.1.1

--- a/test/amiadapters/outputs/test_s3.py
+++ b/test/amiadapters/outputs/test_s3.py
@@ -1,0 +1,154 @@
+import datetime
+import json
+from unittest.mock import MagicMock, call
+
+import pytz
+
+from amiadapters.base import GeneralModelJSONEncoder
+from amiadapters.models import GeneralMeter, GeneralMeterRead
+from amiadapters.outputs.base import ExtractOutput
+from amiadapters.outputs.s3 import S3TaskOutputController
+from test.base_test_case import BaseTestCase
+
+
+class TestS3TaskOutputController(BaseTestCase):
+
+    def setUp(self):
+        self.bucket = "test-bucket"
+        self.org_id = "org-abc"
+        self.prefix = "my-prefix"
+        self.controller = S3TaskOutputController(
+            bucket_name=self.bucket, org_id=self.org_id, s3_prefix=self.prefix
+        )
+
+        self.mock_s3 = MagicMock()
+        self.controller.s3 = self.mock_s3  # Inject mock S3 client
+
+    def test_write_extract_outputs(self):
+        outputs = ExtractOutput({"file1.txt": "data1", "file2.txt": "data2"})
+        self.controller.write_extract_outputs("run-001", outputs)
+
+        calls = self.mock_s3.put_object.call_args_list
+        expected = [
+            call(
+                Bucket="test-bucket",
+                Key="my-prefix/run-001/org-abc/e/file1.txt",
+                Body=b"data1",
+            ),
+            call(
+                Bucket="test-bucket",
+                Key="my-prefix/run-001/org-abc/e/file2.txt",
+                Body=b"data2",
+            ),
+        ]
+        self.assertEqual(expected, calls)
+
+    def test_read_extract_outputs(self):
+        self.mock_s3.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": f"{self.prefix}/run-001/{self.org_id}/e/file1.txt"},
+                {"Key": f"{self.prefix}/run-001/{self.org_id}/e/file2.txt"},
+            ]
+        }
+        self.mock_s3.get_object.side_effect = lambda Bucket, Key: {
+            "Body": MagicMock(read=lambda: b"test-content-" + Key.encode())
+        }
+
+        result = self.controller.read_extract_outputs("run-001")
+        self.assertIsInstance(result, ExtractOutput)
+        self.assertEqual(len(result.get_outputs()), 2)
+        self.assertTrue("file1.txt" in result.get_outputs())
+        self.assertTrue(result.get_outputs()["file1.txt"].startswith("test-content-"))
+
+    def test_write_and_read_transformed_meters(self):
+        meters = [
+            GeneralMeter(
+                org_id="org456",
+                device_id="1",
+                account_id="303022",
+                location_id="303022",
+                meter_id="1",
+                endpoint_id="130615549",
+                meter_install_date=datetime.datetime(
+                    2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
+                meter_size="0.625",
+                meter_manufacturer="Sensus",
+                multiplier=None,
+                location_address="5391 E. MYSTREET",
+                location_city="Apple",
+                location_state="CA",
+                location_zip="93727",
+            ),
+            GeneralMeter(
+                org_id="org456",
+                device_id="2",
+                account_id="303022",
+                location_id="303022",
+                meter_id="2",
+                endpoint_id="130615549",
+                meter_install_date=datetime.datetime(
+                    2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
+                meter_size="0.625",
+                meter_manufacturer="Sensus",
+                multiplier=None,
+                location_address="5391 E. MYSTREET",
+                location_city="Apple",
+                location_state="CA",
+                location_zip="93727",
+            ),
+        ]
+        self.controller.write_transformed_meters("runid", meters)
+
+        # Simulate download
+        data = "\n".join(json.dumps(m, cls=GeneralModelJSONEncoder) for m in meters)
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=lambda: data.encode())
+        }
+
+        result = self.controller.read_transformed_meters("runid")
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].device_id, "1")
+
+    def test_write_and_read_transformed_meter_reads(self):
+        reads = reads = [
+            GeneralMeterRead(
+                org_id="org456",
+                device_id="1",
+                account_id="303022",
+                location_id="303022",
+                flowtime=datetime.datetime(
+                    2024, 8, 1, 0, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
+                register_value=123.4,
+                register_unit="CCF",
+                interval_value=None,
+                interval_unit=None,
+            ),
+            GeneralMeterRead(
+                org_id="org456",
+                device_id="2",
+                account_id="303022",
+                location_id="303022",
+                flowtime=datetime.datetime(
+                    2024, 8, 1, 1, 59, tzinfo=pytz.timezone("Europe/Rome")
+                ),
+                register_value=227.6,
+                register_unit="CCF",
+                interval_value=None,
+                interval_unit=None,
+            ),
+        ]
+        self.controller.write_transformed_meter_reads("runid", reads)
+
+        # Simulate download
+        data = "\n".join(json.dumps(r, cls=GeneralModelJSONEncoder) for r in reads)
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=lambda: data.encode())
+        }
+
+        result = self.controller.read_transformed_meter_reads("runid")
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[1].device_id, "2")
+        self.assertEqual(result[1].register_value, 227.6)


### PR DESCRIPTION
This PR:
- Adds terraform code to make an S3 bucket and an IAM role to access the bucket. The role is associated to the EC2 that runs Airflow and our DAGs.
- Adds the S3TaskOutputController that stores temporary files in S3
- Hardcodes the Beacon adapter to use S3TaskOutputController

An upcoming PR will make the task output controller configurable.