### PR TITLE
Configurable backfill ranges

### DIFF
--- a/amiadapters/base.py
+++ b/amiadapters/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import List, Tuple, Union
+from typing import List, Tuple
 
 from pytz import timezone
 from pytz.tzinfo import DstTzInfo
@@ -57,11 +57,17 @@ class BaseAMIAdapter(ABC):
         pass
 
     @abstractmethod
-    def calculate_backfill_range(self) -> Tuple[datetime, datetime]:
+    def calculate_backfill_range(
+        self, min_date: datetime, max_date: datetime, interval_days: int
+    ) -> Tuple[datetime, datetime]:
         """
         Used by orchestration code when automated backfills are run. Returns a date range
         for which we should backfill data. Used by the automated backfills to determine their
         extract start and end dates.
+
+        min_date: caps how far back we will backfill
+        max_date: caps how far forward we will backfill
+        interval_days: the number of days of data we should backfill
         """
         pass
 

--- a/amiadapters/run.py
+++ b/amiadapters/run.py
@@ -28,11 +28,11 @@ def run_pipeline(
 
     # If using S3, set an AWS credential profile specified in the config
     if (
-        config.sources[0].task_output_controller.type
+        config._sources[0].task_output_controller.type
         == ConfiguredTaskOutputControllerType.S3
     ):
         boto3.setup_default_session(
-            profile_name=config.sources[0].task_output_controller.dev_aws_profile_name
+            profile_name=config._sources[0].task_output_controller.dev_aws_profile_name
         )
 
     # Calculate date range if not fully specified

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -16,3 +16,11 @@ task_output:
   bucket: my-s3-bucket-name-from-terraform
   # Only used for local development, likely the name of the profile you use for terraform
   dev_profile: my-local-aws-profile
+
+# Optionally specify DAGs for backfills between start_date and end_date
+backfills:
+- org_id: my_utility
+  start_date: 2025-02-01
+  end_date: 2025-04-01
+  interval_days: 2
+  schedule: "15 * * * *"

--- a/test/amiadapters/test_config.py
+++ b/test/amiadapters/test_config.py
@@ -110,6 +110,7 @@ class TestConfig(BaseTestCase):
         self.assertEqual(datetime(2025, 1, 1), backfills[0].start_date)
         self.assertEqual(datetime(2025, 2, 1), backfills[0].end_date)
         self.assertEqual(3, backfills[0].interval_days)
+        self.assertEqual("15 * * * *", backfills[0].schedule)
 
         self.assertEqual(datetime(2024, 10, 22), backfills[1].start_date)
         self.assertEqual(datetime(2024, 11, 22), backfills[1].end_date)

--- a/test/fixtures/beacon-360-config.yaml
+++ b/test/fixtures/beacon-360-config.yaml
@@ -13,3 +13,17 @@ sinks:
 task_output:
   type: s3
   bucket: my-bucket
+
+backfills:
+- org_id: my_utility
+  start_date: 2025-01-01
+  end_date: 2025-02-01
+  interval_days: 3
+- org_id: my_utility
+  start_date: 2024-10-22
+  end_date: 2024-11-22
+  interval_days: 4
+- org_id: ignore-me-i-do-not-match-any-org
+  start_date: 2025-01-01
+  end_date: 2025-02-01
+  interval_days: 3

--- a/test/fixtures/beacon-360-config.yaml
+++ b/test/fixtures/beacon-360-config.yaml
@@ -19,11 +19,14 @@ backfills:
   start_date: 2025-01-01
   end_date: 2025-02-01
   interval_days: 3
+  schedule: "15 * * * *"
 - org_id: my_utility
   start_date: 2024-10-22
   end_date: 2024-11-22
   interval_days: 4
+  schedule: "* 1 * * *"
 - org_id: ignore-me-i-do-not-match-any-org
   start_date: 2025-01-01
   end_date: 2025-02-01
   interval_days: 3
+  schedule: "0 12 3 * *"


### PR DESCRIPTION
This PR adds the ability to specify ranges for backfills in the config. Each backfill says which org_id should be backfilled and for which start-end date. The DAG code automatically creates DAGs for each of these ranges.

This might be overkill, but for an AMI provider like Beacon 360 with its API limitations, I think this will be helpful for automatically and slowly closing data gaps.

I've configured the CaDC pipeline to close that Feb-Apr data gap and continue its historical data backfill.