### PR TITLE
Fix configured backfill ranges and use reads-per-day percentile heuristic for calculating the range

### DIFF
--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -310,8 +310,6 @@ class Beacon360Adapter(BaseAMIAdapter):
         Return range report as CSV string, first line with headers.
         Retrieve from cache if configured to do so.
         """
-        self.validate_extract_range(extract_range_start, extract_range_end)
-
         if self.use_cache:
             logger.info("Attempting to load report from cache")
             cached_report = self._get_cached_report(
@@ -560,27 +558,6 @@ class Beacon360Adapter(BaseAMIAdapter):
         return os.path.join(
             self.CACHE_OUTPUT_FOLDER, f"{self.name()}-{start}-{end}-cached-report.txt"
         )
-
-    def calculate_backfill_range(
-        self, min_date: datetime, max_date: datetime, interval_days: int
-    ) -> Tuple[datetime, datetime]:
-        snowflake_sink = [
-            s for s in self.storage_sinks if isinstance(s, BeaconSnowflakeStorageSink)
-        ]
-        if not snowflake_sink:
-            start = datetime.now()
-            end = start - timedelta(days=interval_days)
-        else:
-            sink = snowflake_sink[0]
-            start = sink.get_oldest_meter_read_time(self.org_id)
-            end = start - timedelta(days=interval_days)
-
-        if start <= min_date and end <= min_date:
-            return None
-        elif start >= max_date and end >= max_date:
-            return None
-        else:
-            return start, end
 
 
 class BeaconSnowflakeStorageSink(SnowflakeStorageSink):

--- a/amiadapters/config.py
+++ b/amiadapters/config.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import List, Union
 import pathlib
-from pytz import timezone
+from pytz import timezone, UTC
 from pytz.tzinfo import DstTzInfo
 import yaml
 
@@ -137,8 +137,12 @@ class AMIAdapterConfiguration:
             backfills.append(
                 Backfill(
                     org_id=org_id,
-                    start_date=datetime.combine(start_date, datetime.min.time()),
-                    end_date=datetime.combine(end_date, datetime.min.time()),
+                    start_date=datetime.combine(
+                        start_date, datetime.min.time(), tzinfo=UTC
+                    ),
+                    end_date=datetime.combine(
+                        end_date, datetime.min.time(), tzinfo=UTC
+                    ),
                     interval_days=interval_days,
                     schedule=schedule,
                 )

--- a/amiadapters/sentryx.py
+++ b/amiadapters/sentryx.py
@@ -236,9 +236,6 @@ class SentryxAdapter(BaseAMIAdapter):
     def _extract_consumption_for_all_meters(
         self, extract_range_start: datetime, extract_range_end: datetime
     ) -> List[SentryxMeterWithReads]:
-
-        self.validate_extract_range(extract_range_start, extract_range_end)
-
         url = f"{BASE_URL}/{self.utility_name}/devices/consumption"
 
         headers = {
@@ -369,9 +366,6 @@ class SentryxAdapter(BaseAMIAdapter):
                 meter_reads.append(read)
 
         return list(meters_by_id.values()), meter_reads
-
-    def calculate_backfill_range(self) -> Tuple[datetime, datetime]:
-        raise Exception("Not implemented")
 
     def _raw_meter_output_file(self) -> str:
         return os.path.join(self.output_folder, f"{self.name()}-raw-meters.txt")

--- a/test/amiadapters/test_base.py
+++ b/test/amiadapters/test_base.py
@@ -212,8 +212,10 @@ class TestExtractRangeCalculator(BaseTestCase):
         # Verify results
         self.assertEqual(result_start, expected_start)
         self.assertEqual(result_end, expected_end)
-    
-    def test_calculate_extract_range__backfill_with_snowflake_sink_that_gives_no_oldest_time(self):
+
+    def test_calculate_extract_range__backfill_with_snowflake_sink_that_gives_no_oldest_time(
+        self,
+    ):
         start_date = datetime(2025, 4, 20, 12, 0, 0)
         end_date = datetime(2025, 4, 25, 12, 0, 0)
         self.snowflake_sink.get_oldest_meter_read_time.return_value = None

--- a/test/amiadapters/test_base.py
+++ b/test/amiadapters/test_base.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytz
 
-from amiadapters.base import default_date_range
+from amiadapters.base import ExtractRangeCalculator
 from amiadapters.beacon import Beacon360Adapter
-from amiadapters.config import ConfiguredLocalTaskOutputController
+from amiadapters.config import Backfill, ConfiguredLocalTaskOutputController
+from amiadapters.storage.snowflake import SnowflakeStorageSink
 from test.base_test_case import BaseTestCase
 
 
@@ -76,11 +77,30 @@ class TestBaseAdapter(BaseTestCase):
             result = self.adapter.map_unit_of_measure(size)
             self.assertEqual(result, expected)
 
+    def test_extract_consumption_for_all_meters__throws_exception_when_range_not_valid(
+        self,
+    ):
+        with self.assertRaises(Exception) as context:
+            self.adapter._validate_extract_range(None, self.range_end)
 
-class TestDefaultDateRange(BaseTestCase):
+        with self.assertRaises(Exception) as context:
+            self.adapter._validate_extract_range(self.range_start, None)
+
+        with self.assertRaises(Exception) as context:
+            # End after start
+            self.adapter._validate_extract_range(self.range_end, self.range_start)
+
+
+class TestExtractRangeCalculator(BaseTestCase):
+
+    def setUp(self):
+        self.snowflake_sink = MagicMock(spec=SnowflakeStorageSink)
+        self.snowflake_sink.get_oldest_meter_read_time.return_value = 3
+        sinks = [self.snowflake_sink]
+        self.calculator = ExtractRangeCalculator(org_id="my_org", storage_sinks=sinks)
 
     @patch("amiadapters.base.datetime")
-    def test_both_dates_none(self, mock_datetime):
+    def test_calculate_extract_range__both_dates_none(self, mock_datetime):
         # Set up mock for datetime.now()
         now = datetime(2025, 4, 22, 12, 0, 0)
         mock_datetime.now.return_value = now
@@ -90,14 +110,16 @@ class TestDefaultDateRange(BaseTestCase):
         expected_start = now - timedelta(days=2)
 
         # Test when both start and end are None
-        result_start, result_end = default_date_range(None, None)
+        result_start, result_end = self.calculator.calculate_extract_range(
+            None, None, backfill_params=None
+        )
 
         # Verify results
         self.assertEqual(result_start, expected_start)
         self.assertEqual(result_end, expected_end)
         mock_datetime.now.assert_called_once()
 
-    def test_start_none_end_provided(self):
+    def test_calculate_extract_range__start_none_end_provided(self):
         # Provide end date
         end_date = datetime(2025, 4, 22, 12, 0, 0)
 
@@ -106,13 +128,15 @@ class TestDefaultDateRange(BaseTestCase):
         expected_start = end_date - timedelta(days=2)
 
         # Test when start is None and end is provided
-        result_start, result_end = default_date_range(None, end_date)
+        result_start, result_end = self.calculator.calculate_extract_range(
+            None, end_date, backfill_params=None
+        )
 
         # Verify results
         self.assertEqual(result_start, expected_start)
         self.assertEqual(result_end, expected_end)
 
-    def test_start_provided_end_none(self):
+    def test_calculate_extract_range__start_provided_end_none(self):
         # Provide start date
         start_date = datetime(2025, 4, 20, 12, 0, 0)
 
@@ -121,13 +145,15 @@ class TestDefaultDateRange(BaseTestCase):
         expected_end = start_date + timedelta(days=2)
 
         # Test when start is provided and end is None
-        result_start, result_end = default_date_range(start_date, None)
+        result_start, result_end = self.calculator.calculate_extract_range(
+            start_date, None, backfill_params=None
+        )
 
         # Verify results
         self.assertEqual(result_start, expected_start)
         self.assertEqual(result_end, expected_end)
 
-    def test_both_dates_provided(self):
+    def test_calculate_extract_range__both_dates_provided(self):
         # Provide both dates
         start_date = datetime(2025, 4, 20, 12, 0, 0)
         end_date = datetime(2025, 4, 25, 12, 0, 0)
@@ -137,8 +163,46 @@ class TestDefaultDateRange(BaseTestCase):
         expected_end = end_date
 
         # Test when both start and end are provided
-        result_start, result_end = default_date_range(start_date, end_date)
+        result_start, result_end = self.calculator.calculate_extract_range(
+            start_date, end_date, backfill_params=None
+        )
 
         # Verify results
         self.assertEqual(result_start, expected_start)
         self.assertEqual(result_end, expected_end)
+
+    def test_calculate_extract_range__backfill_with_no_snowflake_sink(self):
+        start_date = datetime(2025, 4, 20, 12, 0, 0)
+        end_date = datetime(2025, 4, 25, 12, 0, 0)
+        backfill_params = Backfill(
+            org_id=self.calculator.org_id,
+            start_date=start_date,
+            end_date=end_date,
+            interval_days=3,
+            schedule="",
+        )
+
+        self.calculator.storage_sinks = [MagicMock()]
+
+        with self.assertRaises(Exception):
+            self.calculator.calculate_extract_range(
+                None, None, backfill_params=backfill_params
+            )
+
+    def test_calculate_extract_range__backfill_with_snowflake_sink(self):
+        start_date = datetime(2025, 4, 20, 12, 0, 0)
+        end_date = datetime(2025, 4, 25, 12, 0, 0)
+        backfill_params = Backfill(
+            org_id=self.calculator.org_id,
+            start_date=start_date,
+            end_date=end_date,
+            interval_days=3,
+            schedule="",
+        )
+
+        self.calculator.storage_sinks = [MagicMock()]
+
+        with self.assertRaises(Exception):
+            self.calculator.calculate_extract_range(
+                None, None, backfill_params=backfill_params
+            )

--- a/test/amiadapters/test_config.py
+++ b/test/amiadapters/test_config.py
@@ -2,6 +2,8 @@ from datetime import datetime
 import pathlib
 from unittest.mock import patch
 
+import pytz
+
 from amiadapters.beacon import Beacon360Adapter
 from amiadapters.config import (
     AMIAdapterConfiguration,
@@ -107,13 +109,15 @@ class TestConfig(BaseTestCase):
         backfills = config.backfills()
         self.assertEqual(2, len(backfills))
 
-        self.assertEqual(datetime(2025, 1, 1), backfills[0].start_date)
-        self.assertEqual(datetime(2025, 2, 1), backfills[0].end_date)
+        self.assertEqual(datetime(2025, 1, 1, tzinfo=pytz.UTC), backfills[0].start_date)
+        self.assertEqual(datetime(2025, 2, 1, tzinfo=pytz.UTC), backfills[0].end_date)
         self.assertEqual(3, backfills[0].interval_days)
         self.assertEqual("15 * * * *", backfills[0].schedule)
 
-        self.assertEqual(datetime(2024, 10, 22), backfills[1].start_date)
-        self.assertEqual(datetime(2024, 11, 22), backfills[1].end_date)
+        self.assertEqual(
+            datetime(2024, 10, 22, tzinfo=pytz.UTC), backfills[1].start_date
+        )
+        self.assertEqual(datetime(2024, 11, 22, tzinfo=pytz.UTC), backfills[1].end_date)
         self.assertEqual(4, backfills[1].interval_days)
 
     def test_can_create_adapters(self):

--- a/test/amiadapters/test_sentryx.py
+++ b/test/amiadapters/test_sentryx.py
@@ -257,21 +257,6 @@ class TestSentryxAdapter(BaseTestCase):
         ]
         self.assertListEqual(calls, mock_get.call_args_list)
 
-    def test_extract_consumption_for_all_meters__throws_exception_when_range_not_valid(
-        self,
-    ):
-        with self.assertRaises(Exception) as context:
-            self.adapter._extract_consumption_for_all_meters(None, self.range_end)
-
-        with self.assertRaises(Exception) as context:
-            self.adapter._extract_consumption_for_all_meters(self.range_start, None)
-
-        with self.assertRaises(Exception) as context:
-            # End after start
-            self.adapter._extract_consumption_for_all_meters(
-                self.range_end, self.range_start
-            )
-
     @mock.patch(
         "requests.get",
         side_effect=[


### PR DESCRIPTION
This PR:
- Has a refactor to split out the code that calculates extract ranges. I think this makes the code easier to read and test.
- Changes the extract range calculation so that it tries to automatically determine which dates within a backfill gap have already been backfilled. It calculates a threshold of reads-per-day that signify which days have already been backfilled, then uses that threshold to find the next day we should backfill.

There was a bug in the previous implementation that should be fixed now.