### PR TITLE
Email alerts to users when DAG runs fail

### DIFF
--- a/amideploy/infrastructure/variables.tf
+++ b/amideploy/infrastructure/variables.tf
@@ -35,3 +35,8 @@ variable "ami_connect_tag" {
   type        = string
   default     = "ami-connect"
 }
+
+variable "alert_emails" {
+  description = "List of emails to subscribe to the Airflow SNS topic for Aiflow alerts"
+  type        = list(string)
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ boto3==1.38.5
 # Installs with constraints for Python 3.12
 apache-airflow==2.10.5 --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.12.txt
 apache-airflow-providers-snowflake==6.1.1
+apache-airflow-providers-amazon==9.8.0
 
 # Running production Airflow
 psycopg2-binary==2.9.10

--- a/test/fixtures/beacon-360-config.yaml
+++ b/test/fixtures/beacon-360-config.yaml
@@ -14,6 +14,10 @@ task_output:
   type: s3
   bucket: my-bucket
 
+notifications:
+  dag_failure:
+    sns_arn: my-sns-arn
+
 backfills:
 - org_id: my_utility
   start_date: 2025-01-01


### PR DESCRIPTION
This sets up email alerts when DAG runs fail. It uses an SNS topic that's set up in terraform. The SNS ARN must be included in the pipeline configuration, else we don't send alerts.

Kept it pretty simple for now so that we can move on to more adapters. Let me know what you think!