### PR TITLE
Refactor raw data loading to remove funky code in adapter constructors

### DIFF
--- a/amiadapters/storage/base.py
+++ b/amiadapters/storage/base.py
@@ -5,6 +5,10 @@ from amiadapters.outputs.base import BaseTaskOutputController
 
 
 class BaseAMIStorageSink(ABC):
+    """
+    A storage sink is any place the AMI Connect pipeline
+    outputs data. Examples: Snowflake, local storage.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
One rough edge when implementing a new adapter is implementing raw data loads. The "controlling" code for a raw data load is in the base adapter. But each adapter must define its own way of loading raw data because the shape of the raw data is different per adapter. But then the "controlling" code in the base class needs to call "down" into the adapter implementation, which breaks the abstraction.

I took a shortcut early on to make it work, resulting in some funky and copy/pasted code. This cleans it up, though I still am not in love with how it looks.