### PR TITLE
Fix snowflake upsert when values are null

### DIFF
--- a/amiadapters/base.py
+++ b/amiadapters/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
+import logging
 from typing import List, Tuple
 
 from pytz import timezone
@@ -14,6 +15,8 @@ from amiadapters.outputs.local import LocalTaskOutputController
 from amiadapters.outputs.s3 import S3TaskOutputController
 from amiadapters.storage.base import BaseAMIStorageSink
 from amiadapters.storage.snowflake import SnowflakeStorageSink, RawSnowflakeLoader
+
+logger = logging.getLogger(__name__)
 
 
 class BaseAMIAdapter(ABC):
@@ -158,7 +161,10 @@ class BaseAMIAdapter(ABC):
             "5/8x3/4": "0.625x0.75",
             "5/8x3/4in": "0.625x0.75",
         }
-        return mapping.get(size)
+        result = mapping.get(size)
+        if result is None:
+            logging.info(f"Unable to map meter size: {size}")
+        return result
 
     def map_unit_of_measure(self, unit_of_measure: str) -> str:
         """
@@ -170,7 +176,10 @@ class BaseAMIAdapter(ABC):
             "CCF": GeneralMeterUnitOfMeasure.HUNDRED_CUBIC_FEET,
             "Gallon": GeneralMeterUnitOfMeasure.GALLON,
         }
-        return mapping.get(unit_of_measure)
+        result = mapping.get(unit_of_measure)
+        if result is None:
+            logging.info(f"Unable to map unit of measure: {unit_of_measure}")
+        return result
 
     def _validate_extract_range(
         self, extract_range_start: datetime, extract_range_end: datetime

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -108,17 +108,17 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
                 FROM temp_meters tm2
                 JOIN meters m2 ON tm2.org_id = m2.org_id AND tm2.device_id = m2.device_id
                 WHERE m2.row_active_until IS NULL AND
-                    CONCAT(tm2.account_id, '|', tm2.location_id, '|', tm2.meter_id, '|', tm2.endpoint_id, '|', tm2.meter_install_date, '|', tm2.meter_size, '|', tm2.meter_manufacturer, '|', tm2.multiplier, '|', tm2.location_address, '|', tm2.location_city, '|', tm2.location_state, '|', tm2.location_zip, '|')
+                    ARRAY_CONSTRUCT(tm2.account_id, tm2.location_id, tm2.meter_id, tm2.endpoint_id, tm2.meter_install_date, tm2.meter_size, tm2.meter_manufacturer, tm2.multiplier, tm2.location_address, tm2.location_city, tm2.location_state, tm2.location_zip)
                     <>
-                    CONCAT(m2.account_id, '|', m2.location_id, '|', m2.meter_id, '|', m2.endpoint_id, '|', m2.meter_install_date, '|', m2.meter_size, '|', m2.meter_manufacturer, '|', m2.multiplier, '|', m2.location_address, '|', m2.location_city, '|', m2.location_state, '|', m2.location_zip, '|')
+                    ARRAY_CONSTRUCT(m2.account_id, m2.location_id, m2.meter_id, m2.endpoint_id, m2.meter_install_date, m2.meter_size, m2.meter_manufacturer, m2.multiplier, m2.location_address, m2.location_city, m2.location_state, m2.location_zip)
             ) AS source
 
             ON CONCAT(target.org_id, '|', target.device_id) = source.merge_key
             WHEN MATCHED
                 AND target.row_active_until IS NULL
-                AND CONCAT(target.account_id, '|', target.location_id, '|', target.meter_id, '|', target.endpoint_id, '|', target.meter_install_date, '|', target.meter_size, '|', target.meter_manufacturer, '|', target.multiplier, '|', target.location_address, '|', target.location_city, '|', target.location_state, '|', target.location_zip, '|')
+                AND ARRAY_CONSTRUCT(target.account_id, target.location_id, target.meter_id, target.endpoint_id, target.meter_install_date, target.meter_size, target.meter_manufacturer, target.multiplier, target.location_address, target.location_city, target.location_state, target.location_zip)
                     <>
-                    CONCAT(source.account_id, '|', source.location_id, '|', source.meter_id, '|', source.endpoint_id, '|', source.meter_install_date, '|', source.meter_size, '|', source.meter_manufacturer, '|', source.multiplier, '|', source.location_address, '|', source.location_city, '|', source.location_state, '|', source.location_zip, '|')
+                    ARRAY_CONSTRUCT(source.account_id, source.location_id, source.meter_id, source.endpoint_id, source.meter_install_date, source.meter_size, source.meter_manufacturer, source.multiplier, source.location_address, source.location_city, source.location_state, source.location_zip)
             THEN
                 UPDATE SET
                     target.row_active_until = '{row_active_from.isoformat()}'

--- a/test/amiadapters/storage/test_snowflake.py
+++ b/test/amiadapters/storage/test_snowflake.py
@@ -79,17 +79,17 @@ class TestSnowflakeStorageSink(BaseTestCase):
                 FROM temp_meters tm2
                 JOIN meters m2 ON tm2.org_id = m2.org_id AND tm2.device_id = m2.device_id
                 WHERE m2.row_active_until IS NULL AND
-                    CONCAT(tm2.account_id, '|', tm2.location_id, '|', tm2.meter_id, '|', tm2.endpoint_id, '|', tm2.meter_install_date, '|', tm2.meter_size, '|', tm2.meter_manufacturer, '|', tm2.multiplier, '|', tm2.location_address, '|', tm2.location_city, '|', tm2.location_state, '|', tm2.location_zip, '|')
+                    ARRAY_CONSTRUCT(tm2.account_id, tm2.location_id, tm2.meter_id, tm2.endpoint_id, tm2.meter_install_date, tm2.meter_size, tm2.meter_manufacturer, tm2.multiplier, tm2.location_address, tm2.location_city, tm2.location_state, tm2.location_zip)
                     <>
-                    CONCAT(m2.account_id, '|', m2.location_id, '|', m2.meter_id, '|', m2.endpoint_id, '|', m2.meter_install_date, '|', m2.meter_size, '|', m2.meter_manufacturer, '|', m2.multiplier, '|', m2.location_address, '|', m2.location_city, '|', m2.location_state, '|', m2.location_zip, '|')
+                    ARRAY_CONSTRUCT(m2.account_id, m2.location_id, m2.meter_id, m2.endpoint_id, m2.meter_install_date, m2.meter_size, m2.meter_manufacturer, m2.multiplier, m2.location_address, m2.location_city, m2.location_state, m2.location_zip)
             ) AS source
 
             ON CONCAT(target.org_id, '|', target.device_id) = source.merge_key
             WHEN MATCHED
                 AND target.row_active_until IS NULL
-                AND CONCAT(target.account_id, '|', target.location_id, '|', target.meter_id, '|', target.endpoint_id, '|', target.meter_install_date, '|', target.meter_size, '|', target.meter_manufacturer, '|', target.multiplier, '|', target.location_address, '|', target.location_city, '|', target.location_state, '|', target.location_zip, '|')
+                AND ARRAY_CONSTRUCT(target.account_id, target.location_id, target.meter_id, target.endpoint_id, target.meter_install_date, target.meter_size, target.meter_manufacturer, target.multiplier, target.location_address, target.location_city, target.location_state, target.location_zip)
                     <>
-                    CONCAT(source.account_id, '|', source.location_id, '|', source.meter_id, '|', source.endpoint_id, '|', source.meter_install_date, '|', source.meter_size, '|', source.meter_manufacturer, '|', source.multiplier, '|', source.location_address, '|', source.location_city, '|', source.location_state, '|', source.location_zip, '|')
+                    ARRAY_CONSTRUCT(source.account_id, source.location_id, source.meter_id, source.endpoint_id, source.meter_install_date, source.meter_size, source.meter_manufacturer, source.multiplier, source.location_address, source.location_city, source.location_state, source.location_zip)
             THEN
                 UPDATE SET
                     target.row_active_until = '2025-04-22T21:01:37.605366+00:00'


### PR DESCRIPTION
While investigating a bug with meter_size in the generic meters table, I noticed that our upsert wasn't working correctly. It came down to the fact that `CONCAT('a', null, 'b') == null` in Snowflake, which messed up the upsert query's logic to find rows that needed updated. I've switched `CONCAT` to `ARRAY_CONSTRUCT` and it's working with some manual tests I ran.

This was a bummer to come across - I am surprised I didn't catch it with initial testing. Fortunately, it should be self-healing - we shouldn't be missing any meters in today's dataset and after this is deployed all meters will get an update if they need it.