### PR TITLE
Second attempt to extract for specific meter IDs

### DIFF
--- a/amiadapters/aclara.py
+++ b/amiadapters/aclara.py
@@ -84,7 +84,11 @@ class AclaraAdapter(BaseAMIAdapter):
         return f"aclara-{self.org_id}"
 
     def extract(
-        self, run_id: str, extract_range_start: datetime, extract_range_end: datetime
+        self,
+        run_id: str,
+        extract_range_start: datetime,
+        extract_range_end: datetime,
+        device_ids: List[str] = None,
     ):
         logging.info(
             f"Connecting to Aclara SFTP for data between {extract_range_start} and {extract_range_end}"

--- a/amiadapters/base.py
+++ b/amiadapters/base.py
@@ -54,14 +54,19 @@ class BaseAMIAdapter(ABC):
 
     @abstractmethod
     def extract(
-        self, run_id: str, extract_range_start: datetime, extract_range_end: datetime
+        self,
+        run_id: str,
+        extract_range_start: datetime,
+        extract_range_end: datetime,
+        device_ids: List[str] = None,
     ):
         """
         Extract data from an AMI data source.
 
         :run_id: identifier for this run of the pipeline, is used to store intermediate output files
-        :extract_range_start datetime: start of meter read datetime range for which we'll extract data
-        :extract_range_end datetime:   end of meter read datetime range for which we'll extract data
+        :extract_range_start datetime:  start of meter read datetime range for which we'll extract data
+        :extract_range_end datetime:    end of meter read datetime range for which we'll extract data
+        :device_ids optional list[str]: list of devices for which we'll extract
         """
         pass
 

--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -122,10 +122,10 @@ class Beacon360Adapter(BaseAMIAdapter):
         run_id: str,
         extract_range_start: datetime,
         extract_range_end: datetime,
-        meter_ids: List[str] = None,
+        device_ids: List[str] = None,
     ):
         report = self._fetch_range_report(
-            extract_range_start, extract_range_end, meter_ids=meter_ids
+            extract_range_start, extract_range_end, device_ids=device_ids
         )
         logger.info("Fetched report")
         self.output_controller.write_extract_outputs(
@@ -146,7 +146,7 @@ class Beacon360Adapter(BaseAMIAdapter):
         self,
         extract_range_start: datetime,
         extract_range_end: datetime,
-        meter_ids: List[str] = None,
+        device_ids: List[str] = None,
     ) -> str:
         """
         Return range report as CSV string, first line with headers.
@@ -174,8 +174,8 @@ class Beacon360Adapter(BaseAMIAdapter):
             "Header_Columns": ",".join(REQUESTED_COLUMNS),
             "Has_Endpoint": True,
         }
-        if meter_ids:
-            params["Meter_ID"] = ",".join(meter_ids)
+        if device_ids:
+            params["Meter_ID"] = ",".join(device_ids)
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
 

--- a/amiadapters/config.py
+++ b/amiadapters/config.py
@@ -142,7 +142,6 @@ class AMIAdapterConfiguration:
             end_date = backfill_config.get("end_date")
             interval_days = backfill_config.get("interval_days")
             schedule = backfill_config.get("schedule")
-            meter_ids = backfill_config.get("meter_ids")
             if any(
                 i is None
                 for i in [org_id, start_date, end_date, interval_days, schedule]
@@ -161,7 +160,6 @@ class AMIAdapterConfiguration:
                     ),
                     interval_days=interval_days,
                     schedule=schedule,
-                    meter_ids=meter_ids,
                 )
             )
 
@@ -368,7 +366,6 @@ class Backfill:
     end_date: datetime
     interval_days: str  # Number of days to backfill in one run
     schedule: str  # crontab-formatted string specifying run schedule
-    meter_ids: Optional[List[str]] = None
 
 
 @dataclass

--- a/amiadapters/sentryx.py
+++ b/amiadapters/sentryx.py
@@ -175,7 +175,11 @@ class SentryxAdapter(BaseAMIAdapter):
         return f"sentryx-api-{self.org_id}"
 
     def extract(
-        self, run_id: str, extract_range_start: datetime, extract_range_end: datetime
+        self,
+        run_id: str,
+        extract_range_start: datetime,
+        extract_range_end: datetime,
+        device_ids: List[str] = None,
     ):
         logger.info(
             f"Extracting {self.org_id} data from {extract_range_start} to {extract_range_end}"

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -49,7 +49,13 @@ def ami_control_dag_factory(
                 start_from_params, end_from_params, backfill_params=backfill_params
             )
 
-            adapter.extract(run_id, start, end, meter_ids=backfill_params.meter_ids)
+            device_ids = (
+                context["params"]["device_ids"].split(",")
+                if "device_ids" in context["params"]
+                else None
+            )
+
+            adapter.extract(run_id, start, end, device_ids=device_ids)
 
         @task()
         def transform(adapter: BaseAMIAdapter, **context):
@@ -108,6 +114,11 @@ for adapter in utility_adapters:
         "extract_range_end": Param(
             type="string",
             description="End of date range for which we'll extract meter read data",
+            default="",
+        ),
+        "device_ids": Param(
+            type="string",
+            description="Comma separated list of device_ids for which we'll extract meter read data",
             default="",
         ),
     }

--- a/test/amiadapters/test_beacon.py
+++ b/test/amiadapters/test_beacon.py
@@ -243,7 +243,7 @@ class TestBeacon360Adapter(BaseTestCase):
         self, mock_sleep, mock_post, mock_get
     ):
         self.adapter._fetch_range_report(
-            self.range_start, self.range_end, meter_ids=["m1", "m2"]
+            self.range_start, self.range_end, device_ids=["m1", "m2"]
         )
 
         self.assertEqual(1, len(mock_post.call_args_list))

--- a/test/amiadapters/test_config.py
+++ b/test/amiadapters/test_config.py
@@ -107,7 +107,6 @@ class TestConfig(BaseTestCase):
         self.assertEqual(datetime(2025, 2, 1, tzinfo=pytz.UTC), backfills[0].end_date)
         self.assertEqual(3, backfills[0].interval_days)
         self.assertEqual("15 * * * *", backfills[0].schedule)
-        self.assertEqual(["m1", "m2"], backfills[0].meter_ids)
 
         self.assertEqual(
             datetime(2024, 10, 22, tzinfo=pytz.UTC), backfills[1].start_date

--- a/test/fixtures/beacon-360-config.yaml
+++ b/test/fixtures/beacon-360-config.yaml
@@ -24,9 +24,6 @@ backfills:
   end_date: 2025-02-01
   interval_days: 3
   schedule: "15 * * * *"
-  meter_ids:
-  - m1
-  - m2
 - org_id: my_utility
   start_date: 2024-10-22
   end_date: 2024-11-22


### PR DESCRIPTION
I decided it's better to do this via a parameter in the manual job, rather than via the backfill configs. Doing it in a backfill means the code tries to automatically calculate the start and end date, which isn't what we want for this scenario.