### PR TITLE
Fix snowflake upserts and add integration tests; Log when we cannot map meter size or unit of measure

### DIFF
--- a/amiadapters/base.py
+++ b/amiadapters/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
+import logging
 from typing import List, Tuple
 
 from pytz import timezone
@@ -14,6 +15,8 @@ from amiadapters.outputs.local import LocalTaskOutputController
 from amiadapters.outputs.s3 import S3TaskOutputController
 from amiadapters.storage.base import BaseAMIStorageSink
 from amiadapters.storage.snowflake import SnowflakeStorageSink, RawSnowflakeLoader
+
+logger = logging.getLogger(__name__)
 
 
 class BaseAMIAdapter(ABC):
@@ -163,7 +166,10 @@ class BaseAMIAdapter(ABC):
             "5/8x3/4": "0.625x0.75",
             "5/8x3/4in": "0.625x0.75",
         }
-        return mapping.get(size)
+        result = mapping.get(size)
+        if result is None:
+            logging.info(f"Unable to map meter size: {size}")
+        return result
 
     def map_unit_of_measure(self, unit_of_measure: str) -> str:
         """
@@ -175,7 +181,10 @@ class BaseAMIAdapter(ABC):
             "CCF": GeneralMeterUnitOfMeasure.HUNDRED_CUBIC_FEET,
             "Gallon": GeneralMeterUnitOfMeasure.GALLON,
         }
-        return mapping.get(unit_of_measure)
+        result = mapping.get(unit_of_measure)
+        if result is None:
+            logging.info(f"Unable to map unit of measure: {unit_of_measure}")
+        return result
 
     def _validate_extract_range(
         self, extract_range_start: datetime, extract_range_end: datetime

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -110,17 +110,17 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
                 FROM temp_meters tm2
                 JOIN meters m2 ON tm2.org_id = m2.org_id AND tm2.device_id = m2.device_id
                 WHERE m2.row_active_until IS NULL AND
-                    CONCAT(tm2.account_id, '|', tm2.location_id, '|', tm2.meter_id, '|', tm2.endpoint_id, '|', tm2.meter_install_date, '|', tm2.meter_size, '|', tm2.meter_manufacturer, '|', tm2.multiplier, '|', tm2.location_address, '|', tm2.location_city, '|', tm2.location_state, '|', tm2.location_zip, '|')
+                    ARRAY_CONSTRUCT(tm2.account_id, tm2.location_id, tm2.meter_id, tm2.endpoint_id, tm2.meter_install_date, tm2.meter_size, tm2.meter_manufacturer, tm2.multiplier, tm2.location_address, tm2.location_city, tm2.location_state, tm2.location_zip)
                     <>
-                    CONCAT(m2.account_id, '|', m2.location_id, '|', m2.meter_id, '|', m2.endpoint_id, '|', m2.meter_install_date, '|', m2.meter_size, '|', m2.meter_manufacturer, '|', m2.multiplier, '|', m2.location_address, '|', m2.location_city, '|', m2.location_state, '|', m2.location_zip, '|')
+                    ARRAY_CONSTRUCT(m2.account_id, m2.location_id, m2.meter_id, m2.endpoint_id, m2.meter_install_date, m2.meter_size, m2.meter_manufacturer, m2.multiplier, m2.location_address, m2.location_city, m2.location_state, m2.location_zip)
             ) AS source
 
             ON CONCAT(target.org_id, '|', target.device_id) = source.merge_key
             WHEN MATCHED
                 AND target.row_active_until IS NULL
-                AND CONCAT(target.account_id, '|', target.location_id, '|', target.meter_id, '|', target.endpoint_id, '|', target.meter_install_date, '|', target.meter_size, '|', target.meter_manufacturer, '|', target.multiplier, '|', target.location_address, '|', target.location_city, '|', target.location_state, '|', target.location_zip, '|')
+                AND ARRAY_CONSTRUCT(target.account_id, target.location_id, target.meter_id, target.endpoint_id, target.meter_install_date, target.meter_size, target.meter_manufacturer, target.multiplier, target.location_address, target.location_city, target.location_state, target.location_zip)
                     <>
-                    CONCAT(source.account_id, '|', source.location_id, '|', source.meter_id, '|', source.endpoint_id, '|', source.meter_install_date, '|', source.meter_size, '|', source.meter_manufacturer, '|', source.multiplier, '|', source.location_address, '|', source.location_city, '|', source.location_state, '|', source.location_zip, '|')
+                    ARRAY_CONSTRUCT(source.account_id, source.location_id, source.meter_id, source.endpoint_id, source.meter_install_date, source.meter_size, source.meter_manufacturer, source.multiplier, source.location_address, source.location_city, source.location_state, source.location_zip)
             THEN
                 UPDATE SET
                     target.row_active_until = '{row_active_from.isoformat()}'

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -101,25 +101,6 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
         rows = [self._meter_tuple(m, row_active_from) for m in meters]
         conn.cursor().executemany(insert_to_temp_table_sql, rows)
 
-        # heya = f"""
-        # SELECT CONCAT(tm.org_id, '|', tm.device_id) as merge_key, tm.*
-        #             FROM {temp_table_name} tm
-
-        #             UNION ALL
-
-        #             SELECT NULL as merge_key, tm2.*
-        #             FROM {temp_table_name} tm2
-        #             JOIN {table_name} m2 ON tm2.org_id = m2.org_id AND tm2.device_id = m2.device_id
-        #             WHERE m2.row_active_until IS NULL AND
-        #                 CONCAT(tm2.account_id, '|', tm2.location_id, '|', tm2.meter_id, '|', tm2.endpoint_id, '|', tm2.meter_install_date, '|', tm2.meter_size, '|', tm2.meter_manufacturer, '|', tm2.multiplier, '|', tm2.location_address, '|', tm2.location_city, '|', tm2.location_state, '|', tm2.location_zip, '|')
-        #                 <>
-        #             CONCAT(m2.account_id, '|', m2.location_id, '|', m2.meter_id, '|', m2.endpoint_id, '|', m2.meter_install_date, '|', m2.meter_size, '|', m2.meter_manufacturer, '|', m2.multiplier, '|', m2.location_address, '|', m2.location_city, '|', m2.location_state, '|', m2.location_zip, '|')
-        # """
-        # conn.cursor().execute(heya)
-        # result = [i for i in conn.fetchall()]
-        # print(result)
-        # import pdb; pdb.set_trace()
-
         # We use a Type 2 Slowly Changing Dimension pattern for our meters table
         # Our implementation follows a pattern in this blog post: https://medium.com/@amit-jsr/implementing-scd2-in-snowflake-slowly-changing-dimension-type-2-7ff793647150
         # It's extremely important that the source table has no duplicates on the "merge_key"!
@@ -182,16 +163,17 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
         ]
         return tuple(result)
 
-    def _upsert_reads(self, reads: List[GeneralMeterRead], conn):
+    def _upsert_reads(self, reads: List[GeneralMeterRead], conn, table_name="readings"):
         self._verify_no_duplicate_reads(reads)
 
+        temp_table_name = f"temp_{table_name}"
         create_temp_table_sql = (
-            "CREATE OR REPLACE TEMPORARY TABLE temp_readings LIKE readings;"
+            f"CREATE OR REPLACE TEMPORARY TABLE {temp_table_name} LIKE {table_name};"
         )
         conn.cursor().execute(create_temp_table_sql)
 
-        insert_to_temp_table_sql = """
-            INSERT INTO temp_readings (
+        insert_to_temp_table_sql = f"""
+            INSERT INTO {temp_table_name} (
                 org_id, device_id, account_id, location_id, flowtime, 
                 register_value, register_unit, interval_value, interval_unit
             ) 
@@ -200,14 +182,14 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
         rows = [self._meter_read_tuple(m) for m in reads]
         conn.cursor().executemany(insert_to_temp_table_sql, rows)
 
-        merge_sql = """
-            MERGE INTO readings AS target
+        merge_sql = f"""
+            MERGE INTO {table_name} AS target
             USING (
                 -- Use GROUP BY to ensure there are no duplicate rows before merge
                 SELECT org_id, device_id, flowtime, max(account_id) as account_id, max(location_id) as location_id, 
                     max(register_value) as register_value, max(register_unit) as register_unit,
                     max(interval_value) as interval_value, max(interval_unit) as interval_unit
-                FROM temp_readings
+                FROM {temp_table_name}
                 GROUP BY org_id, device_id, flowtime
             ) AS source
             ON source.org_id = target.org_id 
@@ -228,26 +210,6 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
                     source.register_value, source.register_unit, source.interval_value, source.interval_unit)
         """
         conn.cursor().execute(merge_sql)
-
-    def _verify_no_duplicate_meters(self, meters: List[GeneralMeter]):
-        seen = set()
-        for meter in meters:
-            key = (meter.org_id, meter.device_id)
-            if key in seen:
-                raise ValueError(
-                    f"Encountered duplicate meter in data for Snowflake: {key}"
-                )
-            seen.add(key)
-
-    def _verify_no_duplicate_reads(self, reads: List[GeneralMeterRead]):
-        seen = set()
-        for read in reads:
-            key = (read.org_id, read.device_id, read.flowtime)
-            if key in seen:
-                raise ValueError(
-                    f"Encountered duplicate read in data for Snowflake: {key}"
-                )
-            seen.add(key)
 
     def _meter_read_tuple(self, read: GeneralMeterRead):
         result = [

--- a/test/amiadapters/storage/test_snowflake.py
+++ b/test/amiadapters/storage/test_snowflake.py
@@ -141,7 +141,6 @@ class TestSnowflakeStorageSink(BaseTestCase):
             )
 
     def test_upsert_reads(self):
-
         reads = [
             GeneralMeterRead(
                 org_id="this-utility",

--- a/test/amiadapters/storage/test_snowflake.py
+++ b/test/amiadapters/storage/test_snowflake.py
@@ -79,17 +79,17 @@ class TestSnowflakeStorageSink(BaseTestCase):
                 FROM temp_meters tm2
                 JOIN meters m2 ON tm2.org_id = m2.org_id AND tm2.device_id = m2.device_id
                 WHERE m2.row_active_until IS NULL AND
-                    CONCAT(tm2.account_id, '|', tm2.location_id, '|', tm2.meter_id, '|', tm2.endpoint_id, '|', tm2.meter_install_date, '|', tm2.meter_size, '|', tm2.meter_manufacturer, '|', tm2.multiplier, '|', tm2.location_address, '|', tm2.location_city, '|', tm2.location_state, '|', tm2.location_zip, '|')
+                    ARRAY_CONSTRUCT(tm2.account_id, tm2.location_id, tm2.meter_id, tm2.endpoint_id, tm2.meter_install_date, tm2.meter_size, tm2.meter_manufacturer, tm2.multiplier, tm2.location_address, tm2.location_city, tm2.location_state, tm2.location_zip)
                     <>
-                    CONCAT(m2.account_id, '|', m2.location_id, '|', m2.meter_id, '|', m2.endpoint_id, '|', m2.meter_install_date, '|', m2.meter_size, '|', m2.meter_manufacturer, '|', m2.multiplier, '|', m2.location_address, '|', m2.location_city, '|', m2.location_state, '|', m2.location_zip, '|')
+                    ARRAY_CONSTRUCT(m2.account_id, m2.location_id, m2.meter_id, m2.endpoint_id, m2.meter_install_date, m2.meter_size, m2.meter_manufacturer, m2.multiplier, m2.location_address, m2.location_city, m2.location_state, m2.location_zip)
             ) AS source
 
             ON CONCAT(target.org_id, '|', target.device_id) = source.merge_key
             WHEN MATCHED
                 AND target.row_active_until IS NULL
-                AND CONCAT(target.account_id, '|', target.location_id, '|', target.meter_id, '|', target.endpoint_id, '|', target.meter_install_date, '|', target.meter_size, '|', target.meter_manufacturer, '|', target.multiplier, '|', target.location_address, '|', target.location_city, '|', target.location_state, '|', target.location_zip, '|')
+                AND ARRAY_CONSTRUCT(target.account_id, target.location_id, target.meter_id, target.endpoint_id, target.meter_install_date, target.meter_size, target.meter_manufacturer, target.multiplier, target.location_address, target.location_city, target.location_state, target.location_zip)
                     <>
-                    CONCAT(source.account_id, '|', source.location_id, '|', source.meter_id, '|', source.endpoint_id, '|', source.meter_install_date, '|', source.meter_size, '|', source.meter_manufacturer, '|', source.multiplier, '|', source.location_address, '|', source.location_city, '|', source.location_state, '|', source.location_zip, '|')
+                    ARRAY_CONSTRUCT(source.account_id, source.location_id, source.meter_id, source.endpoint_id, source.meter_install_date, source.meter_size, source.meter_manufacturer, source.multiplier, source.location_address, source.location_city, source.location_state, source.location_zip)
             THEN
                 UPDATE SET
                     target.row_active_until = '2025-04-22T21:01:37.605366+00:00'

--- a/test/integration/snowflake_integration_test.py
+++ b/test/integration/snowflake_integration_test.py
@@ -1,0 +1,285 @@
+"""
+Manually run integration test for snowflake queries.
+
+Assumes config.yaml and secrets.yaml are set up with an adapter that uses a Snowflake sink.
+
+Usage:
+    python test/integration/snowflake_integration_test.py
+
+"""
+
+import datetime
+
+import pytz
+
+from amiadapters.config import AMIAdapterConfiguration
+from amiadapters.models import GeneralMeter
+from amiadapters.storage.snowflake import SnowflakeStorageSink
+
+
+def run(config: AMIAdapterConfiguration):
+    test_funcs = [
+        test_does_not_insert_or_update_on_duplicate,
+        test_inserts_when_non_matched_row_introduced,
+        test_updates_when_matched_row_has_new_value,
+    ]
+    for fn in test_funcs:
+        fn(config)
+        print(f"✅ {fn.__name__} passed.")
+    print(f"✅ {len(test_funcs)} tests passed.")
+
+
+def setup(config):
+    # Hack!
+    adapter = config.adapters()[0]
+    snowflake_sink = adapter.storage_sinks[0]
+    assert isinstance(snowflake_sink, SnowflakeStorageSink)
+    return snowflake_sink
+
+
+def test_does_not_insert_or_update_on_duplicate(config: AMIAdapterConfiguration):
+    snowflake_sink = setup(config)
+    conn = snowflake_sink.sink_config.connection()
+    cs = conn.cursor()
+    test_table_name = "meters_int_test"
+    row_active_from = datetime.datetime.now(tz=pytz.UTC)
+    try:
+        # Mimic the main table
+        cs.execute(f"CREATE OR REPLACE TEMPORARY TABLE {test_table_name} LIKE meters;")
+
+        # Verify no rows
+        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
+        result = cs.fetchone()[0]
+        assert result == 0, f"Expected 0 rows, got {result}"
+
+        # Add one meter
+        meter = GeneralMeter(
+            org_id="org1",
+            device_id="device1",
+            account_id="303022",
+            location_id="303022",
+            meter_id="1470158170",
+            endpoint_id="130615549",
+            meter_install_date=datetime.datetime(
+                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+            ),
+            meter_size="0.625",
+            meter_manufacturer="BADGER",
+            multiplier=1,
+            location_address="5391 E. MYSTREET",
+            location_city="Apple",
+            location_state="CA",
+            location_zip="93727",
+        )
+        snowflake_sink._upsert_meters(
+            [meter], conn, row_active_from=row_active_from, table_name=test_table_name
+        )
+
+        # Verify added
+        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
+        result = cs.fetchone()[0]
+        assert result == 1, f"Expected 1 row, got {result}"
+
+        # Add the row again, expecting that the upsert doesn't change anything
+        snowflake_sink._upsert_meters([meter], conn, table_name=test_table_name)
+
+        # Verify a new row was not created
+        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
+        result = cs.fetchone()[0]
+        assert result == 1, f"Expected 1 row, got {result}"
+        # Verify row_active_from amd row_active_until values
+        cs.execute(f"SELECT * FROM {test_table_name}")
+        result = cs.fetchone()
+        assert (
+            result[-2] == row_active_from
+        ), f"Unexpected row_active_from, expected {row_active_from} but got {result[-2]}"
+        assert result[-1] is None, f"Unexpected row_active_until, got {result[-1]}"
+    finally:
+        conn.close()
+
+
+def test_inserts_when_non_matched_row_introduced(config: AMIAdapterConfiguration):
+    snowflake_sink = setup(config)
+    conn = snowflake_sink.sink_config.connection()
+    cs = conn.cursor()
+    test_table_name = "meters_int_test"
+    row_active_from = datetime.datetime.now(tz=pytz.UTC)
+    try:
+        # Mimic the main table
+        cs.execute(f"CREATE OR REPLACE TEMPORARY TABLE {test_table_name} LIKE meters;")
+
+        # Verify no rows
+        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
+        result = cs.fetchone()[0]
+        assert result == 0, f"Expected 0 rows, got {result}"
+
+        # Add one meter
+        meter = GeneralMeter(
+            org_id="org1",
+            device_id="device1",
+            account_id="303022",
+            location_id="303022",
+            meter_id="1470158170",
+            endpoint_id="130615549",
+            meter_install_date=datetime.datetime(
+                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+            ),
+            meter_size="0.625",
+            meter_manufacturer="BADGER",
+            multiplier=1,
+            location_address="5391 E. MYSTREET",
+            location_city="Apple",
+            location_state="CA",
+            location_zip="93727",
+        )
+        snowflake_sink._upsert_meters(
+            [meter], conn, row_active_from=row_active_from, table_name=test_table_name
+        )
+
+        # Verify added
+        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
+        result = cs.fetchone()[0]
+        assert result == 1, f"Expected 1 row, got {result}"
+
+        # Add new meters, expecting that the upsert creates a new row
+        new_device_same_org = GeneralMeter(
+            org_id="org1",
+            # New device_id
+            device_id="device2",
+            account_id="303022",
+            location_id="303022",
+            meter_id="2",
+            endpoint_id="2",
+            meter_install_date=datetime.datetime(
+                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+            ),
+            meter_size="0.625",
+            meter_manufacturer="BADGER",
+            multiplier=1,
+            location_address="5391 E. MYSTREET",
+            location_city="Apple",
+            location_state="CA",
+            location_zip="93727",
+        )
+        new_org_same_device_id = GeneralMeter(
+            # New org
+            org_id="org2",
+            # Same device_id
+            device_id="device1",
+            account_id="303022",
+            location_id="303022",
+            meter_id="2",
+            endpoint_id="2",
+            meter_install_date=datetime.datetime(
+                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+            ),
+            meter_size="0.625",
+            meter_manufacturer="BADGER",
+            multiplier=1,
+            location_address="5391 E. MYSTREET",
+            location_city="Apple",
+            location_state="CA",
+            location_zip="93727",
+        )
+        snowflake_sink._upsert_meters(
+            [new_device_same_org, new_org_same_device_id],
+            conn,
+            row_active_from=row_active_from,
+            table_name=test_table_name,
+        )
+
+        # Verify new rows were created
+        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
+        result = cs.fetchone()[0]
+        assert result == 3, f"Expected 3 rows, got {result}"
+    finally:
+        conn.close()
+
+
+def test_updates_when_matched_row_has_new_value(config: AMIAdapterConfiguration):
+    snowflake_sink = setup(config)
+    conn = snowflake_sink.sink_config.connection()
+    cs = conn.cursor()
+    test_table_name = "meters_int_test"
+    row_active_from = datetime.datetime.now(tz=pytz.UTC)
+    try:
+        # Mimic the main table
+        cs.execute(f"CREATE OR REPLACE TEMPORARY TABLE {test_table_name} LIKE meters;")
+
+        # Verify no rows
+        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
+        result = cs.fetchone()[0]
+        assert result == 0, f"Expected 0 rows, got {result}"
+
+        # Add one meter
+        meter = GeneralMeter(
+            org_id="org1",
+            device_id="device1",
+            account_id="303022",
+            location_id="303022",
+            meter_id="1470158170",
+            endpoint_id="130615549",
+            meter_install_date=datetime.datetime(
+                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+            ),
+            meter_size="0.625",
+            meter_manufacturer="BADGER",
+            multiplier=1,
+            location_address="5391 E. MYSTREET",
+            location_city="Apple",
+            location_state="CA",
+            location_zip="93727",
+        )
+        snowflake_sink._upsert_meters(
+            [meter], conn, row_active_from=row_active_from, table_name=test_table_name
+        )
+
+        # Verify added
+        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
+        result = cs.fetchone()[0]
+        assert result == 1, f"Expected 1 row, got {result}"
+
+        # Update the endpoint_id, expecting that the upsert creates a new row with the new endpoint_id and sets row_active_from and row_active_until
+        same_meter_new_endpoint_id = GeneralMeter(
+            org_id="org1",
+            device_id="device1",
+            account_id="303022",
+            location_id="303022",
+            meter_id="2",
+            endpoint_id="9090909",
+            meter_install_date=datetime.datetime(
+                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
+            ),
+            meter_size="0.625",
+            meter_manufacturer="BADGER",
+            multiplier=None,
+            location_address="5391 E. MYSTREET",
+            location_city="Apple",
+            location_state="CA",
+            location_zip="93727",
+        )
+        snowflake_sink._upsert_meters(
+            [same_meter_new_endpoint_id],
+            conn,
+            row_active_from=row_active_from,
+            table_name=test_table_name,
+        )
+
+        # Verify new row was created
+        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
+        result = cs.fetchone()[0]
+        assert result == 2, f"Expected 2 rows, got {result}"
+
+        # Verify only one row with null row_active_until
+        cs.execute(
+            f"SELECT COUNT(*) FROM {test_table_name} WHERE row_active_until IS NULL"
+        )
+        result = cs.fetchone()[0]
+        assert result == 1, f"Expected 1 row, got {result}"
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    config = AMIAdapterConfiguration.from_yaml("config.yaml", "secrets.yaml")
+    run(config)

--- a/test/integration/snowflake_integration_test.py
+++ b/test/integration/snowflake_integration_test.py
@@ -1,65 +1,174 @@
 """
-Manually run integration test for snowflake queries.
+Run integration test for snowflake queries.
 
+Does not run with CI, you must run this manually.
 Assumes config.yaml and secrets.yaml are set up with an adapter that uses a Snowflake sink.
+Connects to production Snowflake.
 
 Usage:
     python test/integration/snowflake_integration_test.py
 
 """
 
+import unittest
 import datetime
-
 import pytz
 
 from amiadapters.config import AMIAdapterConfiguration
-from amiadapters.models import GeneralMeter
+from amiadapters.models import GeneralMeter, GeneralMeterRead
 from amiadapters.storage.snowflake import SnowflakeStorageSink
 
 
-def run(config: AMIAdapterConfiguration):
-    test_funcs = [
-        test_does_not_insert_or_update_on_duplicate,
-        test_inserts_when_non_matched_row_introduced,
-        test_updates_when_matched_row_has_new_value,
-    ]
-    for fn in test_funcs:
-        fn(config)
-        print(f"✅ {fn.__name__} passed.")
-    print(f"✅ {len(test_funcs)} tests passed.")
+class TestSnowflakeUpserts(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.config = AMIAdapterConfiguration.from_yaml("config.yaml", "secrets.yaml")
+        # Hack!
+        adapter = cls.config.adapters()[0]
+        cls.snowflake_sink = adapter.storage_sinks[0]
+        assert isinstance(cls.snowflake_sink, SnowflakeStorageSink)
+        cls.test_meters_table = "meters_int_test"
+        cls.test_readings_table = "readings_int_test"
+        cls.conn = cls.snowflake_sink.sink_config.connection()
+        cls.cs = cls.conn.cursor()
 
-def setup(config):
-    # Hack!
-    adapter = config.adapters()[0]
-    snowflake_sink = adapter.storage_sinks[0]
-    assert isinstance(snowflake_sink, SnowflakeStorageSink)
-    return snowflake_sink
+    @classmethod
+    def tearDownClass(cls):
+        cls.conn.close()
 
+    def setUp(self):
+        self.row_active_from = datetime.datetime.now(tz=pytz.UTC)
+        self.cs.execute(
+            f"CREATE OR REPLACE TEMPORARY TABLE {self.test_meters_table} LIKE meters;"
+        )
+        self.cs.execute(
+            f"CREATE OR REPLACE TEMPORARY TABLE {self.test_readings_table} LIKE readings;"
+        )
 
-def test_does_not_insert_or_update_on_duplicate(config: AMIAdapterConfiguration):
-    snowflake_sink = setup(config)
-    conn = snowflake_sink.sink_config.connection()
-    cs = conn.cursor()
-    test_table_name = "meters_int_test"
-    row_active_from = datetime.datetime.now(tz=pytz.UTC)
-    try:
-        # Mimic the main table
-        cs.execute(f"CREATE OR REPLACE TEMPORARY TABLE {test_table_name} LIKE meters;")
+    def test_upsert_meters_does_not_insert_or_update_on_duplicate(self):
+        self._assert_num_rows(self.test_meters_table, 0)
 
-        # Verify no rows
-        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
-        result = cs.fetchone()[0]
-        assert result == 0, f"Expected 0 rows, got {result}"
+        meter = self._create_meter(device_id="device1")
+        self.snowflake_sink._upsert_meters(
+            [meter],
+            self.conn,
+            row_active_from=self.row_active_from,
+            table_name=self.test_meters_table,
+        )
 
-        # Add one meter
-        meter = GeneralMeter(
-            org_id="org1",
-            device_id="device1",
+        self._assert_num_rows(self.test_meters_table, 1)
+
+        self.snowflake_sink._upsert_meters(
+            [meter], self.conn, table_name=self.test_meters_table
+        )
+
+        self._assert_num_rows(self.test_meters_table, 1)
+        self.cs.execute(f"SELECT * FROM {self.test_meters_table}")
+        result = self.cs.fetchone()
+        self.assertEqual(result[-2], self.row_active_from)
+        self.assertIsNone(result[-1])
+
+    def test_upsert_meters_inserts_when_non_matched_row_introduced(self):
+        self._assert_num_rows(self.test_meters_table, 0)
+
+        meter1 = self._create_meter(device_id="device1")
+        self.snowflake_sink._upsert_meters(
+            [meter1],
+            self.conn,
+            row_active_from=self.row_active_from,
+            table_name=self.test_meters_table,
+        )
+
+        meter2 = self._create_meter(device_id="device2")
+        meter3 = self._create_meter(device_id="device1", org_id="org2")
+        self.snowflake_sink._upsert_meters(
+            [meter2, meter3],
+            self.conn,
+            row_active_from=self.row_active_from,
+            table_name=self.test_meters_table,
+        )
+
+        self._assert_num_rows(self.test_meters_table, 3)
+
+    def test_upsert_meters_updates_when_matched_row_has_new_value(self):
+        self._assert_num_rows(self.test_meters_table, 0)
+
+        meter = self._create_meter(device_id="device1", endpoint_id="130615549")
+        self.snowflake_sink._upsert_meters(
+            [meter],
+            self.conn,
+            row_active_from=self.row_active_from,
+            table_name=self.test_meters_table,
+        )
+
+        updated_meter = self._create_meter(device_id="device1", endpoint_id="9090909")
+        self.snowflake_sink._upsert_meters(
+            [updated_meter],
+            self.conn,
+            row_active_from=self.row_active_from,
+            table_name=self.test_meters_table,
+        )
+
+        self._assert_num_rows(self.test_meters_table, 2)
+        self.cs.execute(
+            f"SELECT COUNT(*) FROM {self.test_meters_table} WHERE row_active_until IS NULL"
+        )
+        self.assertEqual(self.cs.fetchone()[0], 1)
+
+    def test_upsert_reads_inserts_new_reads(self):
+        self._assert_num_rows(self.test_readings_table, 0)
+        self.snowflake_sink._upsert_reads(
+            [self._create_read()], self.conn, table_name=self.test_readings_table
+        )
+        self._assert_num_rows(self.test_readings_table, 1)
+
+    def test_upsert_reads_updates_existing_read(self):
+        self._assert_num_rows(self.test_readings_table, 0)
+        read_initial = self._create_read()
+        self.snowflake_sink._upsert_reads(
+            [read_initial], self.conn, table_name=self.test_readings_table
+        )
+
+        read_updated = self._create_read(account_id="acct2", location_id="loc2")
+
+        self.snowflake_sink._upsert_reads(
+            [read_updated], self.conn, table_name=self.test_readings_table
+        )
+
+        self.cs.execute(f"SELECT * FROM {self.test_readings_table}")
+        rows = self.cs.fetchall()
+        self.assertEqual(len(rows), 1)
+        updated_row = rows[0]
+        self.assertEqual(updated_row[1], "acct2")  # account_id
+        self.assertEqual(updated_row[2], "loc2")  # location_id
+        self.assertEqual(updated_row[5], 100.0)  # register_value
+
+    def test_upsert_reads_inserts_new_row_when_not_matched(self):
+        self._assert_num_rows(self.test_readings_table, 0)
+
+        read_initial = self._create_read()
+        self.snowflake_sink._upsert_reads(
+            [read_initial], self.conn, table_name=self.test_readings_table
+        )
+
+        new_read = self._create_read(device_id="other")
+        self.snowflake_sink._upsert_reads(
+            [new_read], self.conn, table_name=self.test_readings_table
+        )
+
+        self._assert_num_rows(self.test_readings_table, 2)
+
+    def _create_meter(
+        self, org_id="org1", device_id="device1", endpoint_id="130615549"
+    ) -> GeneralMeter:
+        return GeneralMeter(
+            org_id=org_id,
+            device_id=device_id,
             account_id="303022",
             location_id="303022",
             meter_id="1470158170",
-            endpoint_id="130615549",
+            endpoint_id=endpoint_id,
             meter_install_date=datetime.datetime(
                 2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
             ),
@@ -71,215 +180,30 @@ def test_does_not_insert_or_update_on_duplicate(config: AMIAdapterConfiguration)
             location_state="CA",
             location_zip="93727",
         )
-        snowflake_sink._upsert_meters(
-            [meter], conn, row_active_from=row_active_from, table_name=test_table_name
-        )
 
-        # Verify added
-        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
-        result = cs.fetchone()[0]
-        assert result == 1, f"Expected 1 row, got {result}"
-
-        # Add the row again, expecting that the upsert doesn't change anything
-        snowflake_sink._upsert_meters([meter], conn, table_name=test_table_name)
-
-        # Verify a new row was not created
-        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
-        result = cs.fetchone()[0]
-        assert result == 1, f"Expected 1 row, got {result}"
-        # Verify row_active_from amd row_active_until values
-        cs.execute(f"SELECT * FROM {test_table_name}")
-        result = cs.fetchone()
-        assert (
-            result[-2] == row_active_from
-        ), f"Unexpected row_active_from, expected {row_active_from} but got {result[-2]}"
-        assert result[-1] is None, f"Unexpected row_active_until, got {result[-1]}"
-    finally:
-        conn.close()
-
-
-def test_inserts_when_non_matched_row_introduced(config: AMIAdapterConfiguration):
-    snowflake_sink = setup(config)
-    conn = snowflake_sink.sink_config.connection()
-    cs = conn.cursor()
-    test_table_name = "meters_int_test"
-    row_active_from = datetime.datetime.now(tz=pytz.UTC)
-    try:
-        # Mimic the main table
-        cs.execute(f"CREATE OR REPLACE TEMPORARY TABLE {test_table_name} LIKE meters;")
-
-        # Verify no rows
-        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
-        result = cs.fetchone()[0]
-        assert result == 0, f"Expected 0 rows, got {result}"
-
-        # Add one meter
-        meter = GeneralMeter(
+    def _create_read(
+        self,
+        device_id: str = "dev1",
+        account_id: str = "acct1",
+        location_id: str = "loc1",
+    ) -> GeneralMeterRead:
+        return GeneralMeterRead(
             org_id="org1",
-            device_id="device1",
-            account_id="303022",
-            location_id="303022",
-            meter_id="1470158170",
-            endpoint_id="130615549",
-            meter_install_date=datetime.datetime(
-                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
-            ),
-            meter_size="0.625",
-            meter_manufacturer="BADGER",
-            multiplier=1,
-            location_address="5391 E. MYSTREET",
-            location_city="Apple",
-            location_state="CA",
-            location_zip="93727",
-        )
-        snowflake_sink._upsert_meters(
-            [meter], conn, row_active_from=row_active_from, table_name=test_table_name
+            device_id=device_id,
+            account_id=account_id,
+            location_id=location_id,
+            flowtime=datetime.datetime(2024, 1, 1, tzinfo=pytz.UTC),
+            register_value=100.0,
+            register_unit="GAL",
+            interval_value=10.0,
+            interval_unit="GAL",
         )
 
-        # Verify added
-        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
-        result = cs.fetchone()[0]
-        assert result == 1, f"Expected 1 row, got {result}"
-
-        # Add new meters, expecting that the upsert creates a new row
-        new_device_same_org = GeneralMeter(
-            org_id="org1",
-            # New device_id
-            device_id="device2",
-            account_id="303022",
-            location_id="303022",
-            meter_id="2",
-            endpoint_id="2",
-            meter_install_date=datetime.datetime(
-                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
-            ),
-            meter_size="0.625",
-            meter_manufacturer="BADGER",
-            multiplier=1,
-            location_address="5391 E. MYSTREET",
-            location_city="Apple",
-            location_state="CA",
-            location_zip="93727",
-        )
-        new_org_same_device_id = GeneralMeter(
-            # New org
-            org_id="org2",
-            # Same device_id
-            device_id="device1",
-            account_id="303022",
-            location_id="303022",
-            meter_id="2",
-            endpoint_id="2",
-            meter_install_date=datetime.datetime(
-                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
-            ),
-            meter_size="0.625",
-            meter_manufacturer="BADGER",
-            multiplier=1,
-            location_address="5391 E. MYSTREET",
-            location_city="Apple",
-            location_state="CA",
-            location_zip="93727",
-        )
-        snowflake_sink._upsert_meters(
-            [new_device_same_org, new_org_same_device_id],
-            conn,
-            row_active_from=row_active_from,
-            table_name=test_table_name,
-        )
-
-        # Verify new rows were created
-        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
-        result = cs.fetchone()[0]
-        assert result == 3, f"Expected 3 rows, got {result}"
-    finally:
-        conn.close()
-
-
-def test_updates_when_matched_row_has_new_value(config: AMIAdapterConfiguration):
-    snowflake_sink = setup(config)
-    conn = snowflake_sink.sink_config.connection()
-    cs = conn.cursor()
-    test_table_name = "meters_int_test"
-    row_active_from = datetime.datetime.now(tz=pytz.UTC)
-    try:
-        # Mimic the main table
-        cs.execute(f"CREATE OR REPLACE TEMPORARY TABLE {test_table_name} LIKE meters;")
-
-        # Verify no rows
-        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
-        result = cs.fetchone()[0]
-        assert result == 0, f"Expected 0 rows, got {result}"
-
-        # Add one meter
-        meter = GeneralMeter(
-            org_id="org1",
-            device_id="device1",
-            account_id="303022",
-            location_id="303022",
-            meter_id="1470158170",
-            endpoint_id="130615549",
-            meter_install_date=datetime.datetime(
-                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
-            ),
-            meter_size="0.625",
-            meter_manufacturer="BADGER",
-            multiplier=1,
-            location_address="5391 E. MYSTREET",
-            location_city="Apple",
-            location_state="CA",
-            location_zip="93727",
-        )
-        snowflake_sink._upsert_meters(
-            [meter], conn, row_active_from=row_active_from, table_name=test_table_name
-        )
-
-        # Verify added
-        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
-        result = cs.fetchone()[0]
-        assert result == 1, f"Expected 1 row, got {result}"
-
-        # Update the endpoint_id, expecting that the upsert creates a new row with the new endpoint_id and sets row_active_from and row_active_until
-        same_meter_new_endpoint_id = GeneralMeter(
-            org_id="org1",
-            device_id="device1",
-            account_id="303022",
-            location_id="303022",
-            meter_id="2",
-            endpoint_id="9090909",
-            meter_install_date=datetime.datetime(
-                2016, 1, 1, 23, 59, tzinfo=pytz.timezone("Europe/Rome")
-            ),
-            meter_size="0.625",
-            meter_manufacturer="BADGER",
-            multiplier=None,
-            location_address="5391 E. MYSTREET",
-            location_city="Apple",
-            location_state="CA",
-            location_zip="93727",
-        )
-        snowflake_sink._upsert_meters(
-            [same_meter_new_endpoint_id],
-            conn,
-            row_active_from=row_active_from,
-            table_name=test_table_name,
-        )
-
-        # Verify new row was created
-        cs.execute(f"SELECT COUNT(*) FROM {test_table_name}")
-        result = cs.fetchone()[0]
-        assert result == 2, f"Expected 2 rows, got {result}"
-
-        # Verify only one row with null row_active_until
-        cs.execute(
-            f"SELECT COUNT(*) FROM {test_table_name} WHERE row_active_until IS NULL"
-        )
-        result = cs.fetchone()[0]
-        assert result == 1, f"Expected 1 row, got {result}"
-    finally:
-        conn.close()
+    def _assert_num_rows(self, table_name: str, expected_number_of_rows: int):
+        self.cs.execute(f"SELECT COUNT(*) FROM {table_name}")
+        result = self.cs.fetchone()[0]
+        self.assertEqual(result, expected_number_of_rows)
 
 
 if __name__ == "__main__":
-    config = AMIAdapterConfiguration.from_yaml("config.yaml", "secrets.yaml")
-    run(config)
+    unittest.main()


### PR DESCRIPTION
This reinstates the fix for Snowflake upserts that I tried last week. It uses Snowflake arrays instead of the concat function did not work well with null values for our purposes.

I've added integration tests for Snowflake. These are meant to run manually as needed.

And I've added a bit of logging for when we're unable to map to a meter size or unit of measure. We don't want the job to fail in these cases, but the logging will help us debug issues.