### PR TITLE
Fix device_id for raw beacon data

### DIFF
--- a/amiadapters/beacon.py
+++ b/amiadapters/beacon.py
@@ -421,7 +421,7 @@ class BeaconRawSnowflakeLoader(RawSnowflakeLoader):
         created_time = datetime.now(tz=org_timezone)
         rows = [
             tuple(
-                [org_id, i.Meter_ID, created_time]
+                [org_id, i.Endpoint_SN, created_time]
                 + [i.__getattribute__(name) for name in REQUESTED_COLUMNS]
             )
             for i in raw_meters_with_reads


### PR DESCRIPTION
Forgot to update the device_id for raw beacon data as part of our swap to use the Endpoint_SN field. This makes the fix, and I'll update historical data too.