### PR TITLE
Handle duplicate reads in Aclara data

### DIFF
--- a/test/amiadapters/test_aclara.py
+++ b/test/amiadapters/test_aclara.py
@@ -152,6 +152,17 @@ class TestAclaraAdapter(BaseTestCase):
         self.assertEqual(meter.meter_size, "0.625x0.75")
         self.assertEqual(read.device_id, "1")
         self.assertEqual(read.register_value, 23497.071)
+    
+    def test_deduplicates_during_transform(self):
+        input_data = [
+            self.meter_and_read_factory(),
+            self.meter_and_read_factory()
+        ]
+
+        meters, reads = self.adapter._transform_meters_and_reads(input_data)
+
+        self.assertEqual(len(meters), 1)
+        self.assertEqual(len(reads), 1)
 
     def test_transforms_scaled_read_with_value_ERROR(self):
         input_data = [self.meter_and_read_factory(scaled_read="ERROR")]

--- a/test/amiadapters/test_aclara.py
+++ b/test/amiadapters/test_aclara.py
@@ -152,12 +152,9 @@ class TestAclaraAdapter(BaseTestCase):
         self.assertEqual(meter.meter_size, "0.625x0.75")
         self.assertEqual(read.device_id, "1")
         self.assertEqual(read.register_value, 23497.071)
-    
+
     def test_deduplicates_during_transform(self):
-        input_data = [
-            self.meter_and_read_factory(),
-            self.meter_and_read_factory()
-        ]
+        input_data = [self.meter_and_read_factory(), self.meter_and_read_factory()]
 
         meters, reads = self.adapter._transform_meters_and_reads(input_data)
 


### PR DESCRIPTION
The new check for duplicates we're doing before Snowflake loads caught duplicate reads for an Aclara meter with MeterSN `18423113` on `2025-06-09 08:00:00.000`. This updates the Aclara transform so that it doesn't output duplicates.