### PR TITLE
Refactor config to require less code per new adapter; Add bare bones Metersense adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ how it extracts data from the AMI data source, how it transforms that data into 
 
 Steps:
 1. In a new python file within `amiadapters`, create a new implementation of the `BaseAMIAdapter` abstract class.
-2. define extract
-3. define transform
-4. define raw load, including SQL and anything else for setup
-5. Add to configuration
+2. Define an extract function that retrieves AMI data from a source and outputs it using an output controller. This function shouldn't alter the data much - its output should stay as close to the source data to reduce risk of error and to give us a historical record of the source data via our stored intermediate outputs.
+3. Define a transform function that takes the data from extract and transforms it into our generic data models, then outputs it using an output controller.
+4. If you're loading the raw data into a storage sink, you should define that step using something like RawSnowflakeLoader.
+5. For the pipeline to run your adapter, the `AMIAdapterConfiguration.adapters()` function will need to be able to instantiate your adapter. This will require some code in `config.py`. You'll need to figure out what a block in the `sources` section of the config looks like for your adapter, then be able to parse that block, e.g. within `AMIAdapterConfiguration.from_yaml()`.

--- a/amiadapters/metersense.py
+++ b/amiadapters/metersense.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import List
+
+from amiadapters.base import BaseAMIAdapter
+
+
+class MetersenseAdapter(BaseAMIAdapter):
+    """
+    AMI Adapter that retrieves Xylem/Sensus data from a Metersense Oracle database.
+    """
+
+    def __init__(
+        self,
+        org_id,
+        org_timezone,
+        configured_task_output_controller,
+        configured_sinks=None,
+        raw_snowflake_loader=None,
+    ):
+        super().__init__(
+            org_id,
+            org_timezone,
+            configured_task_output_controller,
+            configured_sinks,
+            raw_snowflake_loader,
+        )
+
+    def name(self) -> str:
+        return f"metersense-{self.org_id}"
+
+    def extract(
+        self,
+        run_id: str,
+        extract_range_start: datetime,
+        extract_range_end: datetime,
+        device_ids: List[str] = None,
+    ):
+        pass
+
+    def transform(self, run_id: str):
+        pass

--- a/test/amiadapters/test_config.py
+++ b/test/amiadapters/test_config.py
@@ -12,6 +12,7 @@ from amiadapters.config import (
     find_config_yaml,
     find_secrets_yaml,
 )
+from amiadapters.metersense import MetersenseAdapter
 from amiadapters.sentryx import SentryxAdapter
 from test.base_test_case import BaseTestCase
 
@@ -94,6 +95,17 @@ class TestConfig(BaseTestCase):
         self.assertEqual("my_user", source.secrets.sftp_user)
         self.assertEqual("my_password", source.secrets.sftp_password)
 
+    def test_can_instantiate_metersense_via_yaml(self):
+        config = AMIAdapterConfiguration.from_yaml(
+            self.get_fixture_path("metersense-config.yaml"),
+            self.get_fixture_path("metersense-secrets.yaml"),
+        )
+        self.assertEqual(1, len(config._sources))
+        source = config._sources[0]
+        self.assertEqual("metersense", source.type)
+        self.assertEqual("my_utility", source.org_id)
+        self.assertEqual("America/Los_Angeles", str(source.timezone))
+
     def test_can_instantiate_backfills_from_yaml(self):
         config = AMIAdapterConfiguration.from_yaml(
             self.get_fixture_path("beacon-360-config.yaml"),
@@ -121,10 +133,11 @@ class TestConfig(BaseTestCase):
         )
         adapters = config.adapters()
 
-        self.assertEqual(3, len(adapters))
+        self.assertEqual(4, len(adapters))
         self.assertIn(AclaraAdapter, map(lambda a: type(a), adapters))
-        self.assertIn(SentryxAdapter, map(lambda a: type(a), adapters))
         self.assertIn(Beacon360Adapter, map(lambda a: type(a), adapters))
+        self.assertIn(MetersenseAdapter, map(lambda a: type(a), adapters))
+        self.assertIn(SentryxAdapter, map(lambda a: type(a), adapters))
 
     def test_can_create_on_failure_notifier(self):
         config = AMIAdapterConfiguration.from_yaml(

--- a/test/amiadapters/test_metersense.py
+++ b/test/amiadapters/test_metersense.py
@@ -1,0 +1,23 @@
+import datetime
+
+import pytz
+
+from amiadapters.config import ConfiguredLocalTaskOutputController
+from amiadapters.metersense import MetersenseAdapter
+from test.base_test_case import BaseTestCase
+
+
+class TestMetersenseAdapter(BaseTestCase):
+
+    def setUp(self):
+        self.adapter = MetersenseAdapter(
+            org_id="this-org",
+            org_timezone=pytz.timezone("Europe/Rome"),
+            configured_task_output_controller=ConfiguredLocalTaskOutputController(
+                "/tmp/output"
+            ),
+            configured_sinks=[],
+        )
+
+    def test_init(self):
+        self.assertIsNotNone(self.adapter)

--- a/test/fixtures/all-config.yaml
+++ b/test/fixtures/all-config.yaml
@@ -21,6 +21,11 @@ sources:
   sftp_local_known_hosts_file: ./known-hosts
   sinks:
   - my_snowflake_instance
+- type: metersense
+  org_id: my_metersense_utility
+  timezone: America/Los_Angeles
+  sinks:
+  - my_snowflake_instance
 
 sinks:
 - type: snowflake

--- a/test/fixtures/metersense-config.yaml
+++ b/test/fixtures/metersense-config.yaml
@@ -1,0 +1,14 @@
+sources:
+- type: metersense
+  org_id: my_utility
+  timezone: America/Los_Angeles
+  sinks:
+  - my_snowflake_instance
+
+sinks:
+- type: snowflake
+  id: my_snowflake_instance
+
+task_output:
+  type: local
+  output_folder: outputs

--- a/test/fixtures/metersense-secrets.yaml
+++ b/test/fixtures/metersense-secrets.yaml
@@ -1,0 +1,12 @@
+sources:
+ my_utility:
+
+sinks:
+  my_snowflake_instance:
+    account: my_account
+    user: my_user
+    password: my_password
+    role: my_role
+    warehouse: my_warehouse
+    database: my_database
+    schema: my_schema


### PR DESCRIPTION
This refactors the `config.py` code to reduce the number of changes necessary to introduce a new adapter type. Particularly, some of the validation was hardcoded before, but is now automated.

This also adds a bare bones Metersense adapter to the codebase. It doesn't do anything yet.