### PR TITLE
Metersense adapter first pass

### DIFF
--- a/amiadapters/metersense.py
+++ b/amiadapters/metersense.py
@@ -1,7 +1,152 @@
+from dataclasses import dataclass
 from datetime import datetime
+import json
+import logging
 from typing import List
 
 from amiadapters.base import BaseAMIAdapter
+from amiadapters.models import DataclassJSONEncoder
+from amiadapters.outputs.base import ExtractOutput
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MetersenseAccountService:
+    """
+    Representation of the ACCOUNT_SERVICES table in Metersense schema.
+    """
+    service_id: str
+    account_id: str
+    location_no: str
+    commodity_tp: str
+    last_read_dt: str
+    active_dt: str
+    inactive_dt: str
+
+
+
+@dataclass
+class MetersenseLocation:
+    """
+    Representation of the LOCATIONS table in Metersense schema.
+    """
+    location_no: str
+    alt_location_id: str
+    location_class: str
+    unit_no: str
+    street_no: str
+    street_pfx: str
+    street_name: str
+    street_sfx: str
+    street_sfx_dir: str
+    city: str
+    state: str
+    postal_cd: str
+    billing_cycle: str
+    add_by: str
+    add_dt: str
+    change_by: str
+    change_dt: str
+    latitude: str
+    longitude: str
+
+
+@dataclass
+class MetersenseMeter:
+    """
+    Representation of the METERS table in Metersense schema.
+    """
+    meter_id: str
+    alt_meter_id: str
+    meter_tp: str
+    commodity_tp: str
+    region_id: str
+    interval_length: str
+    regread_frequency: str
+    channel1_raw_uom: str
+    channel2_raw_uom: str
+    channel3_raw_uom: str
+    channel4_raw_uom: str
+    channel5_raw_uom: str
+    channel6_raw_uom: str
+    channel7_raw_uom: str
+    channel8_raw_uom: str
+    channel1_multiplier: str
+    channel2_multiplier: str
+    channel3_multiplier: str
+    channel4_multiplier: str
+    channel5_multiplier: str
+    channel6_multiplier: str
+    channel7_multiplier: str
+    channel8_multiplier: str
+    channel1_final_uom: str
+    channel2_final_uom: str
+    channel3_final_uom: str
+    channel4_final_uom: str
+    channel5_final_uom: str
+    channel6_final_uom: str
+    channel7_final_uom: str
+    channel8_final_uom: str
+    first_data_ts: str
+    last_data_ts: str
+    ami_id: str
+    power_status: str
+    latitude: str
+    longitude: str
+    exclude_in_reports: str
+    add_by: str
+    add_dt: str
+    change_by: str
+    change_dt: str
+
+
+@dataclass
+class MetersenseMeterLocationXref:
+    """
+    Representation of the METER_LOCATION_XREF table in Metersense schema.
+    """
+    meter_id: str
+    active_dt: str
+    location_no: str
+    inactive_dt: str
+    add_by: str
+    add_dt: str
+    change_by: str
+    change_dt: str
+
+
+@dataclass
+class MetersenseIntervalRead:
+    """
+    Representation of the INTERVALREADS table in Metersense schema.
+    """
+    meter_id: str
+    channel_id: str
+    read_dt: str
+    read_hr: str
+    read_30min_int: str
+    read_15min_int: str
+    read_5min_int: str
+    read_dtm: str
+    read_value: str
+    uom: str
+    status: str
+    read_version: str
+
+
+@dataclass
+class MetersenseRegisterRead:
+    """
+    Representation of the REGISTERREADS table in Metersense schema.
+    """
+    meter_id: str
+    channel_id: str
+    read_dtm: str
+    read_value: str
+    uom: str
+    status: str
+    read_version: str
 
 
 class MetersenseAdapter(BaseAMIAdapter):
@@ -35,7 +180,200 @@ class MetersenseAdapter(BaseAMIAdapter):
         extract_range_end: datetime,
         device_ids: List[str] = None,
     ):
-        pass
+        import oracledb
+        import sshtunnel
+
+        
+        
+
+        with sshtunnel.open_tunnel(
+            (ssh_tunnel_server_ip),
+            ssh_pkey=ssh_key_path,
+            remote_bind_address=(database_host, database_port),
+            local_bind_address=('0.0.0.0', database_port)
+        ) as tunnel:
+            # client = paramiko.SSHClient()
+            # client.load_system_host_keys()
+            # client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            # client.connect('127.0.0.1', 10022)
+            # # do some operations with client session
+            # client.close()
+            logging.info("Created SSH tunnel")
+            connection = oracledb.connect(
+                user=database_user, password=database_password, dsn=f"0.0.0.0:{database_port}/{database_name}"
+            )
+
+        print("Successfully connected to Oracle Database")
+
+        cursor = connection.cursor()
+
+        # Create a table
+
+        cursor.execute(
+            """
+            select * from test
+            """
+        )
+        result = cursor.fetchall()
+        print(result)
+        meters = [
+            MetersenseMeter(
+                meter_id="89671712",
+                alt_meter_id="S89671712",
+                meter_tp="W-DISC34",
+                commodity_tp="W",
+                region_id="California",
+                interval_length="60",
+                regread_frequency="1440",
+                channel1_raw_uom="CF",
+                channel2_raw_uom=None,
+                channel3_raw_uom=None,
+                channel4_raw_uom=None,
+                channel5_raw_uom=None,
+                channel6_raw_uom=None,
+                channel7_raw_uom=None,
+                channel8_raw_uom=None,
+                channel1_multiplier="0.01",
+                channel2_multiplier=None,
+                channel3_multiplier=None,
+                channel4_multiplier=None,
+                channel5_multiplier=None,
+                channel6_multiplier=None,
+                channel7_multiplier=None,
+                channel8_multiplier=None,
+                channel1_final_uom="CCF",
+                channel2_final_uom=None,
+                channel3_final_uom=None,
+                channel4_final_uom=None,
+                channel5_final_uom=None,
+                channel6_final_uom=None,
+                channel7_final_uom=None,
+                channel8_final_uom=None,
+                first_data_ts="2023-02-18 00:00:00.000",
+                last_data_ts="2025-06-15 00:00:00.000",
+                ami_id="default",
+                power_status="ON",
+                latitude="33.8252339",
+                longitude="118.1034094",
+                exclude_in_reports="N",
+                add_by="ODS",
+                add_dt="2023-02-17 23:12:13.000",
+                change_by="ODS",
+                change_dt="2025-06-15 02:22:07.000"
+            ),
+        ]
+
+        meter_location_xrefs = [
+            MetersenseMeterLocationXref(
+                meter_id="89671712",
+                active_dt="2023-02-17 00:00:00.000",
+                location_no="6523400466",
+                inactive_dt="2023-12-25 00:00:00.000",
+                add_by="ODS",
+                add_dt="2024-01-04 23:12:17.000",
+                change_by="ODS",
+                change_dt="2024-01-04 23:12:17.000"
+            ),
+        ]
+
+        account_services = [
+            MetersenseAccountService(
+                service_id="4453033580",
+                account_id="445303358044515438576523400466",
+                location_no="6523400466",
+                commodity_tp="W",
+                last_read_dt="2023-12-25 00:00:00.000",
+                active_dt="2021-03-01 00:00:00.000",
+                inactive_dt="9999-12-31 00:00:00.000"
+            ),
+        ]
+
+        locations = [
+            MetersenseLocation(
+                location_no="6523400466",
+                location_id="6523400466",
+                location_tp="SFD",
+                location_nm=None,
+                location_nm2=None,
+                address1="3730 LOS COYOTES DIA",
+                address2=None,
+                city="LONG BEACH",
+                state="CA",
+                zip="90808-2409",
+                county=None,
+                add_by="ODS",
+                add_dt="2019-10-24 11:47:48.000",
+                change_by="ODS",
+                change_dt="2025-06-10 23:13:20.000",
+                latitude="33.825194555",
+                longitude="118.10331495"
+            ),
+        ]
+
+        register_reads = [
+            MetersenseRegisterRead(
+                meter_id="89671712",
+                channel_id="1",
+                read_dtm="2025-06-14 23:00:00.000",
+                read_value="171.697000",
+                uom="CCF",
+                read_version="1",
+                read_multiplier="1"
+            ),
+        ]
+        interval_reads = [
+            MetersenseIntervalRead(
+                meter_id="89671712",
+                channel_id="1",
+                read_date="2025-06-14",
+                read_hour="23",
+                daylight_savings_ind="0",
+                interval_number="0",
+                interval_status="0",
+                interval_dtm="2025-06-14 23:00:00.000",
+                interval_value="0.003000",
+                uom="CCF",
+                read_version="1",
+                interval_multiplier="1"
+            ),
+            MetersenseIntervalRead(
+                meter_id="89671712",
+                channel_id="1",
+                read_date="2025-06-14",
+                read_hour="24",
+                daylight_savings_ind="0",
+                interval_number="0",
+                interval_status="0",
+                interval_dtm="2025-06-14 23:00:00.000",
+                interval_value="0.000000",
+                uom="CCF",
+                read_version="1",
+                interval_multiplier="1"
+            ),
+        ]
+        self.output_controller.write_extract_outputs(
+            run_id,
+            ExtractOutput({
+                "meters.json": "\n".join(json.dumps(i, cls=DataclassJSONEncoder) for i in meters),
+                "account_services.json": "\n".join(json.dumps(i, cls=DataclassJSONEncoder) for i in account_services),
+                "locations.json": "\n".join(json.dumps(i, cls=DataclassJSONEncoder) for i in locations),
+                "meter_location_xrefs.json": "\n".join(json.dumps(i, cls=DataclassJSONEncoder) for i in meter_location_xrefs),
+                "interval_reads.json": "\n".join(json.dumps(i, cls=DataclassJSONEncoder) for i in interval_reads),
+                "register_reads.json": "\n".join(json.dumps(i, cls=DataclassJSONEncoder) for i in register_reads),
+            }),
+        )
 
     def transform(self, run_id: str):
-        pass
+        extract_outputs = self.output_controller.read_extract_outputs(run_id)
+        raw_account_services = {
+            MetersenseAccountService(**json.loads(d)) for d in extract_outputs.from_file("account_services.json").strip().split("\n")
+        }
+        raw_locations = [
+            MetersenseLocation(**json.loads(d)) for d in extract_outputs.from_file("locations.json").strip().split("\n")
+        ]
+        raw_meters = [
+            MetersenseMeter(**json.loads(d)) for d in extract_outputs.from_file("meters.json").strip().split("\n")
+        ]
+        raw_meter_location_xrefs = [
+            MetersenseMeterLocationXref(**json.loads(d)) for d in extract_outputs.from_file("meter_location_xrefs.json").strip().split("\n")
+        ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ black==25.1.0
 PyYAML==6.0.2
 boto3==1.38.5
 paramiko==3.5.1
+oracledb==3.1.1
+sshtunnel==0.4.0
 # Installs with constraints for Python 3.12
 apache-airflow==2.10.5 --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.12.txt
 apache-airflow-providers-snowflake==6.1.1

--- a/test/amiadapters/test_config.py
+++ b/test/amiadapters/test_config.py
@@ -105,6 +105,20 @@ class TestConfig(BaseTestCase):
         self.assertEqual("metersense", source.type)
         self.assertEqual("my_utility", source.org_id)
         self.assertEqual("America/Los_Angeles", str(source.timezone))
+        self.assertEqual(
+            "tunnel-ip", source.configured_ssh_tunnel_to_database.ssh_tunnel_server_host
+        )
+        self.assertEqual("ubuntu", source.secrets.ssh_tunnel_username)
+        self.assertEqual(
+            "/key", source.configured_ssh_tunnel_to_database.ssh_tunnel_key_path
+        )
+        self.assertEqual(
+            "db-host", source.configured_ssh_tunnel_to_database.database_host
+        )
+        self.assertEqual(1521, source.configured_ssh_tunnel_to_database.database_port)
+        self.assertEqual("db-name", source.secrets.database_db_name)
+        self.assertEqual("dbu", source.secrets.database_user)
+        self.assertEqual("dbp", source.secrets.database_password)
 
     def test_can_instantiate_backfills_from_yaml(self):
         config = AMIAdapterConfiguration.from_yaml(

--- a/test/amiadapters/test_metersense.py
+++ b/test/amiadapters/test_metersense.py
@@ -3,7 +3,12 @@ import datetime
 import pytz
 
 from amiadapters.config import ConfiguredLocalTaskOutputController
-from amiadapters.metersense import MetersenseAdapter, MetersenseIntervalRead, MetersenseMeterLocation, MetersenseRegisterRead
+from amiadapters.metersense import (
+    MetersenseAdapter,
+    MetersenseIntervalRead,
+    MetersenseMeterLocation,
+    MetersenseRegisterRead,
+)
 from test.base_test_case import BaseTestCase
 
 
@@ -18,8 +23,16 @@ class TestMetersenseAdapter(BaseTestCase):
                 "/tmp/output"
             ),
             configured_sinks=[],
+            ssh_tunnel_server_host="tunnel-ip",
+            ssh_tunnel_username="ubuntu",
+            ssh_tunnel_key_path="/key",
+            database_host="db-host",
+            database_port=1521,
+            database_db_name="db-name",
+            database_user="dbu",
+            database_password="dbp",
         )
-    
+
     def _meter_location_factory(self) -> MetersenseMeterLocation:
         return MetersenseMeterLocation(
             meter_id="m1",
@@ -89,50 +102,66 @@ class TestMetersenseAdapter(BaseTestCase):
             accounts_commodity_tp="W",
             last_read_dt="2023-12-25 00:00:00.000",
             active_dt="2021-03-01 00:00:00.000",
-            inactive_dt="9999-12-31 00:00:00.000"
+            inactive_dt="9999-12-31 00:00:00.000",
         )
 
-    def _interval_read_factory(self, meter_id: str = "m1", read_dtm: str = "2024-01-01 01:00:00") -> MetersenseIntervalRead:
+    def _interval_read_factory(
+        self, meter_id: str = "m1", read_dtm: str = "2024-01-01 01:00:00"
+    ) -> MetersenseIntervalRead:
         return MetersenseIntervalRead(
-                meter_id=meter_id,
-                channel_id="1",
-                read_dt=None,
-                read_hr=None,
-                read_30min_int=None,
-                read_15min_int=None,
-                read_5min_int=None,
-                status="status",
-                read_version=1,
-                read_dtm=read_dtm,
-                read_value=0.5,
-                uom="CCF",
-            )
-    
-    def _register_read_factory(self, meter_id: str = "m1", read_dtm: str = "2024-01-01 01:00:00") -> MetersenseRegisterRead:
+            meter_id=meter_id,
+            channel_id="1",
+            read_dt=None,
+            read_hr=None,
+            read_30min_int=None,
+            read_15min_int=None,
+            read_5min_int=None,
+            status="status",
+            read_version=1,
+            read_dtm=read_dtm,
+            read_value=0.5,
+            uom="CCF",
+        )
+
+    def _register_read_factory(
+        self, meter_id: str = "m1", read_dtm: str = "2024-01-01 01:00:00"
+    ) -> MetersenseRegisterRead:
         return MetersenseRegisterRead(
-                meter_id=meter_id,
-                read_dtm=read_dtm,
-                read_value=10.5,
-                uom="CCF",
-                channel_id="1",
-                status="status",
-                read_version=1,
-            )
+            meter_id=meter_id,
+            read_dtm=read_dtm,
+            read_value=10.5,
+            uom="CCF",
+            channel_id="1",
+            status="status",
+            read_version=1,
+        )
 
     def test_init(self):
-        self.assertIsNotNone(self.adapter)
+        self.assertEqual("tunnel-ip", self.adapter.ssh_tunnel_server_host)
+        self.assertEqual("ubuntu", self.adapter.ssh_tunnel_username)
+        self.assertEqual("/key", self.adapter.ssh_tunnel_key_path)
+        self.assertEqual("db-host", self.adapter.database_host)
+        self.assertEqual(1521, self.adapter.database_port)
+        self.assertEqual("db-name", self.adapter.database_db_name)
+        self.assertEqual("dbu", self.adapter.database_user)
+        self.assertEqual("dbp", self.adapter.database_password)
 
     def test_transform_single_meter_and_reads(self):
         m = self._meter_location_factory()
         raw_meters = [m]
         raw_interval_reads = [
-            self._interval_read_factory(meter_id=m.meter_id, read_dtm="2024-01-01 01:00:00"),
-            self._interval_read_factory(meter_id=m.meter_id, read_dtm="2024-01-01 02:00:00"),
-            
+            self._interval_read_factory(
+                meter_id=m.meter_id, read_dtm="2024-01-01 01:00:00"
+            ),
+            self._interval_read_factory(
+                meter_id=m.meter_id, read_dtm="2024-01-01 02:00:00"
+            ),
         ]
         raw_register_reads = [
             # Same read_dtm as first interval read
-            self._register_read_factory(meter_id=m.meter_id, read_dtm="2024-01-01 01:00:00")
+            self._register_read_factory(
+                meter_id=m.meter_id, read_dtm="2024-01-01 01:00:00"
+            )
         ]
 
         meters, reads = self.adapter._transform_meters_and_reads(
@@ -156,7 +185,9 @@ class TestMetersenseAdapter(BaseTestCase):
         self.assertEqual(read_1.register_value, 10.5)
         self.assertEqual(read_1.interval_unit, "CCF")
         self.assertEqual(read_1.register_unit, "CCF")
-        self.assertEqual(read_1.flowtime, datetime.datetime(2024, 1, 1, 1, 0, 0, tzinfo=self.tz))
+        self.assertEqual(
+            read_1.flowtime, datetime.datetime(2024, 1, 1, 1, 0, 0, tzinfo=self.tz)
+        )
 
         read_2 = reads[1]
         self.assertEqual(read_2.device_id, "m1")
@@ -166,14 +197,17 @@ class TestMetersenseAdapter(BaseTestCase):
         self.assertEqual(read_2.register_value, None)
         self.assertEqual(read_2.interval_unit, "CCF")
         self.assertEqual(read_2.register_unit, None)
-        self.assertEqual(read_2.flowtime, datetime.datetime(2024, 1, 1, 2, 0, 0, tzinfo=self.tz))
+        self.assertEqual(
+            read_2.flowtime, datetime.datetime(2024, 1, 1, 2, 0, 0, tzinfo=self.tz)
+        )
 
     def test_transform_missing_register_read(self):
         m = self._meter_location_factory()
         raw_meters = [m]
         raw_interval_reads = [
-            self._interval_read_factory(meter_id=m.meter_id, read_dtm="2024-01-01 01:00:00"),
-            
+            self._interval_read_factory(
+                meter_id=m.meter_id, read_dtm="2024-01-01 01:00:00"
+            ),
         ]
         raw_register_reads = []
 
@@ -191,9 +225,7 @@ class TestMetersenseAdapter(BaseTestCase):
         m = self._meter_location_factory()
         raw_meters = [m]
         raw_interval_reads = []
-        raw_register_reads = [
-            self._register_read_factory(meter_id=m.meter_id)
-        ]
+        raw_register_reads = [self._register_read_factory(meter_id=m.meter_id)]
 
         meters, reads = self.adapter._transform_meters_and_reads(
             raw_meters, raw_interval_reads, raw_register_reads
@@ -204,15 +236,11 @@ class TestMetersenseAdapter(BaseTestCase):
         read = reads[0]
         self.assertIsNone(read.interval_value)
         self.assertEqual(read.register_value, 10.5)
-    
+
     def test_transform_missing_meters(self):
         raw_meters = []
-        raw_interval_reads = [
-            self._interval_read_factory(meter_id="some-meter")
-        ]
-        raw_register_reads = [
-            self._register_read_factory(meter_id="another-meter")
-        ]
+        raw_interval_reads = [self._interval_read_factory(meter_id="some-meter")]
+        raw_register_reads = [self._register_read_factory(meter_id="another-meter")]
 
         meters, reads = self.adapter._transform_meters_and_reads(
             raw_meters, raw_interval_reads, raw_register_reads
@@ -223,7 +251,7 @@ class TestMetersenseAdapter(BaseTestCase):
         read = reads[0]
         self.assertIsNone(read.account_id)
         self.assertIsNone(read.location_id)
-    
+
     def test_transform_duplicate_meters(self):
         raw_meters = [
             self._meter_location_factory(),
@@ -238,7 +266,7 @@ class TestMetersenseAdapter(BaseTestCase):
         )
 
         self.assertEqual(len(meters), 1)
-    
+
     def test_transform_duplicate_interval_reads(self):
         raw_meters = []
         raw_interval_reads = [
@@ -252,7 +280,7 @@ class TestMetersenseAdapter(BaseTestCase):
         )
 
         self.assertEqual(len(reads), 1)
-    
+
     def test_transform_duplicate_register_reads(self):
         raw_meters = []
         raw_interval_reads = []
@@ -266,5 +294,3 @@ class TestMetersenseAdapter(BaseTestCase):
         )
 
         self.assertEqual(len(reads), 1)
-
-

--- a/test/amiadapters/test_metersense.py
+++ b/test/amiadapters/test_metersense.py
@@ -3,21 +3,268 @@ import datetime
 import pytz
 
 from amiadapters.config import ConfiguredLocalTaskOutputController
-from amiadapters.metersense import MetersenseAdapter
+from amiadapters.metersense import MetersenseAdapter, MetersenseIntervalRead, MetersenseMeterLocation, MetersenseRegisterRead
 from test.base_test_case import BaseTestCase
 
 
 class TestMetersenseAdapter(BaseTestCase):
 
     def setUp(self):
+        self.tz = pytz.timezone("Europe/Rome")
         self.adapter = MetersenseAdapter(
             org_id="this-org",
-            org_timezone=pytz.timezone("Europe/Rome"),
+            org_timezone=self.tz,
             configured_task_output_controller=ConfiguredLocalTaskOutputController(
                 "/tmp/output"
             ),
             configured_sinks=[],
         )
+    
+    def _meter_location_factory(self) -> MetersenseMeterLocation:
+        return MetersenseMeterLocation(
+            meter_id="m1",
+            alt_meter_id="altm1",
+            meter_tp="W-DISC34",
+            meters_commodity_tp="W",
+            region_id="California",
+            interval_length="60",
+            regread_frequency="1440",
+            channel1_raw_uom="CF",
+            channel2_raw_uom="",
+            channel3_raw_uom="",
+            channel4_raw_uom="",
+            channel5_raw_uom="",
+            channel6_raw_uom="",
+            channel7_raw_uom="",
+            channel8_raw_uom="",
+            channel1_multiplier="0.01",
+            channel2_multiplier="",
+            channel3_multiplier="",
+            channel4_multiplier="",
+            channel5_multiplier="",
+            channel6_multiplier="",
+            channel7_multiplier="",
+            channel8_multiplier="",
+            channel1_final_uom="CCF",
+            channel2_final_uom="",
+            channel3_final_uom="",
+            channel4_final_uom="",
+            channel5_final_uom="",
+            channel6_final_uom="",
+            channel7_final_uom="",
+            channel8_final_uom="",
+            first_data_ts="2023-02-18 00:00:00.000",
+            last_data_ts="2025-06-15 00:00:00.000",
+            ami_id="default",
+            power_status="ON",
+            meters_latitude="33.8252339",
+            meters_longitude="118.1034094",
+            exclude_in_reports="N",
+            meters_add_by="ODS",
+            meters_add_dt="2023-02-17 23:12:13.000",
+            meters_change_by="ODS",
+            meters_change_dt="2025-06-15 02:22:07.000",
+            locations_location_no="loc1",
+            alt_location_id="loc1",
+            location_class="SFD",
+            unit_no="",
+            street_no="100",
+            street_pfx="",
+            street_name="Metropolis",
+            street_sfx="",
+            street_sfx_dir="",
+            city="Metropolis",
+            state="NY",
+            postal_cd="12345",
+            billing_cycle="",
+            locations_add_by="ODS",
+            locations_add_dt="2019-10-24 11:47:48.000",
+            locations_change_by="ODS",
+            locations_change_dt="2025-06-10 23:13:20.000",
+            locations_latitude="33.825194555",
+            locations_longitude="118.10331495",
+            service_id="serv1",
+            account_id="acc1",
+            accounts_location_no="loc1",
+            accounts_commodity_tp="W",
+            last_read_dt="2023-12-25 00:00:00.000",
+            active_dt="2021-03-01 00:00:00.000",
+            inactive_dt="9999-12-31 00:00:00.000"
+        )
+
+    def _interval_read_factory(self, meter_id: str = "m1", read_dtm: str = "2024-01-01 01:00:00") -> MetersenseIntervalRead:
+        return MetersenseIntervalRead(
+                meter_id=meter_id,
+                channel_id="1",
+                read_dt=None,
+                read_hr=None,
+                read_30min_int=None,
+                read_15min_int=None,
+                read_5min_int=None,
+                status="status",
+                read_version=1,
+                read_dtm=read_dtm,
+                read_value=0.5,
+                uom="CCF",
+            )
+    
+    def _register_read_factory(self, meter_id: str = "m1", read_dtm: str = "2024-01-01 01:00:00") -> MetersenseRegisterRead:
+        return MetersenseRegisterRead(
+                meter_id=meter_id,
+                read_dtm=read_dtm,
+                read_value=10.5,
+                uom="CCF",
+                channel_id="1",
+                status="status",
+                read_version=1,
+            )
 
     def test_init(self):
         self.assertIsNotNone(self.adapter)
+
+    def test_transform_single_meter_and_reads(self):
+        m = self._meter_location_factory()
+        raw_meters = [m]
+        raw_interval_reads = [
+            self._interval_read_factory(meter_id=m.meter_id, read_dtm="2024-01-01 01:00:00"),
+            self._interval_read_factory(meter_id=m.meter_id, read_dtm="2024-01-01 02:00:00"),
+            
+        ]
+        raw_register_reads = [
+            # Same read_dtm as first interval read
+            self._register_read_factory(meter_id=m.meter_id, read_dtm="2024-01-01 01:00:00")
+        ]
+
+        meters, reads = self.adapter._transform_meters_and_reads(
+            raw_meters, raw_interval_reads, raw_register_reads
+        )
+
+        # Meter assertions
+        self.assertEqual(len(meters), 1)
+        meter = meters[0]
+        self.assertEqual(meter.device_id, "m1")
+        self.assertEqual(meter.account_id, "acc1")
+        self.assertEqual(meter.location_zip, "12345")
+
+        # Read assertions
+        self.assertEqual(len(reads), 2)
+        read_1 = reads[0]
+        self.assertEqual(read_1.device_id, "m1")
+        self.assertEqual(read_1.account_id, "acc1")
+        self.assertEqual(read_1.location_id, "loc1")
+        self.assertEqual(read_1.interval_value, 0.5)
+        self.assertEqual(read_1.register_value, 10.5)
+        self.assertEqual(read_1.interval_unit, "CCF")
+        self.assertEqual(read_1.register_unit, "CCF")
+        self.assertEqual(read_1.flowtime, datetime.datetime(2024, 1, 1, 1, 0, 0, tzinfo=self.tz))
+
+        read_2 = reads[1]
+        self.assertEqual(read_2.device_id, "m1")
+        self.assertEqual(read_2.account_id, "acc1")
+        self.assertEqual(read_2.location_id, "loc1")
+        self.assertEqual(read_2.interval_value, 0.5)
+        self.assertEqual(read_2.register_value, None)
+        self.assertEqual(read_2.interval_unit, "CCF")
+        self.assertEqual(read_2.register_unit, None)
+        self.assertEqual(read_2.flowtime, datetime.datetime(2024, 1, 1, 2, 0, 0, tzinfo=self.tz))
+
+    def test_transform_missing_register_read(self):
+        m = self._meter_location_factory()
+        raw_meters = [m]
+        raw_interval_reads = [
+            self._interval_read_factory(meter_id=m.meter_id, read_dtm="2024-01-01 01:00:00"),
+            
+        ]
+        raw_register_reads = []
+
+        meters, reads = self.adapter._transform_meters_and_reads(
+            raw_meters, raw_interval_reads, raw_register_reads
+        )
+
+        self.assertEqual(len(meters), 1)
+        self.assertEqual(len(reads), 1)
+        read = reads[0]
+        self.assertIsNone(read.register_value)
+        self.assertEqual(read.interval_value, 0.5)
+
+    def test_transform_missing_interval_read(self):
+        m = self._meter_location_factory()
+        raw_meters = [m]
+        raw_interval_reads = []
+        raw_register_reads = [
+            self._register_read_factory(meter_id=m.meter_id)
+        ]
+
+        meters, reads = self.adapter._transform_meters_and_reads(
+            raw_meters, raw_interval_reads, raw_register_reads
+        )
+
+        self.assertEqual(len(meters), 1)
+        self.assertEqual(len(reads), 1)
+        read = reads[0]
+        self.assertIsNone(read.interval_value)
+        self.assertEqual(read.register_value, 10.5)
+    
+    def test_transform_missing_meters(self):
+        raw_meters = []
+        raw_interval_reads = [
+            self._interval_read_factory(meter_id="some-meter")
+        ]
+        raw_register_reads = [
+            self._register_read_factory(meter_id="another-meter")
+        ]
+
+        meters, reads = self.adapter._transform_meters_and_reads(
+            raw_meters, raw_interval_reads, raw_register_reads
+        )
+
+        self.assertEqual(len(meters), 0)
+        self.assertEqual(len(reads), 2)
+        read = reads[0]
+        self.assertIsNone(read.account_id)
+        self.assertIsNone(read.location_id)
+    
+    def test_transform_duplicate_meters(self):
+        raw_meters = [
+            self._meter_location_factory(),
+            self._meter_location_factory(),
+            self._meter_location_factory(),
+        ]
+        raw_interval_reads = []
+        raw_register_reads = []
+
+        meters, reads = self.adapter._transform_meters_and_reads(
+            raw_meters, raw_interval_reads, raw_register_reads
+        )
+
+        self.assertEqual(len(meters), 1)
+    
+    def test_transform_duplicate_interval_reads(self):
+        raw_meters = []
+        raw_interval_reads = [
+            self._interval_read_factory(),
+            self._interval_read_factory(),
+        ]
+        raw_register_reads = []
+
+        meters, reads = self.adapter._transform_meters_and_reads(
+            raw_meters, raw_interval_reads, raw_register_reads
+        )
+
+        self.assertEqual(len(reads), 1)
+    
+    def test_transform_duplicate_register_reads(self):
+        raw_meters = []
+        raw_interval_reads = []
+        raw_register_reads = [
+            self._register_read_factory(),
+            self._register_read_factory(),
+        ]
+
+        meters, reads = self.adapter._transform_meters_and_reads(
+            raw_meters, raw_interval_reads, raw_register_reads
+        )
+
+        self.assertEqual(len(reads), 1)
+
+

--- a/test/fixtures/all-config.yaml
+++ b/test/fixtures/all-config.yaml
@@ -24,6 +24,10 @@ sources:
 - type: metersense
   org_id: my_metersense_utility
   timezone: America/Los_Angeles
+  ssh_tunnel_server_host: tunnel-ip
+  ssh_tunnel_key_path: /key
+  database_host: db-host
+  database_port: 1521
   sinks:
   - my_snowflake_instance
 

--- a/test/fixtures/all-secrets.yaml
+++ b/test/fixtures/all-secrets.yaml
@@ -7,6 +7,11 @@ sources:
   my_aclara_utility:
     sftp_user: my_user
     sftp_password: my_password
+  my_metersense_utility:
+    ssh_tunnel_username: ubuntu
+    database_db_name: db-name
+    database_user: dbu
+    database_password: dbp
 
 sinks:
   my_snowflake_instance:

--- a/test/fixtures/metersense-config.yaml
+++ b/test/fixtures/metersense-config.yaml
@@ -2,6 +2,10 @@ sources:
 - type: metersense
   org_id: my_utility
   timezone: America/Los_Angeles
+  ssh_tunnel_server_host: tunnel-ip
+  ssh_tunnel_key_path: /key
+  database_host: db-host
+  database_port: 1521
   sinks:
   - my_snowflake_instance
 

--- a/test/fixtures/metersense-secrets.yaml
+++ b/test/fixtures/metersense-secrets.yaml
@@ -1,5 +1,9 @@
 sources:
  my_utility:
+  ssh_tunnel_username: ubuntu
+  database_db_name: db-name
+  database_user: dbu
+  database_password: dbp
 
 sinks:
   my_snowflake_instance:


### PR DESCRIPTION
Fills out the Metersense adapter with:
- Working configuration and secrets for SSH tunnel and Oracle database connection
- Single SQL extract for meters and their metadata
- SQL extract for register reads
- SQL interval for register reads
- Transform code to create generalized meters and reads
- Unit tests

Remaining TODOs after this PR:
- Confirm we're okay with a single SQL query for all meter metadata
- Answer some questions about the data
- Raw data loads
- Set up SSH tunnel originating from CaDC's AMI Connect Airflow server