### PR TITLE
Refactor abstract function interfaces to reduce repeated code and improve testability

### DIFF
--- a/amiadapters/adapters/aclara.py
+++ b/amiadapters/adapters/aclara.py
@@ -13,7 +13,7 @@ from pytz.tzinfo import DstTzInfo
 from amiadapters.adapters.base import BaseAMIAdapter, GeneralMeterUnitOfMeasure
 from amiadapters.config import ConfiguredSftp
 from amiadapters.models import DataclassJSONEncoder, GeneralMeter, GeneralMeterRead
-from amiadapters.outputs.base import BaseTaskOutputController, ExtractOutput
+from amiadapters.outputs.base import ExtractOutput
 from amiadapters.storage.snowflake import RawSnowflakeLoader
 
 logger = logging.getLogger(__name__)
@@ -339,10 +339,9 @@ class AclaraRawSnowflakeLoader(RawSnowflakeLoader):
         run_id: str,
         org_id: str,
         org_timezone: DstTzInfo,
-        output_controller: BaseTaskOutputController,
+        extract_outputs: ExtractOutput,
         snowflake_conn,
     ):
-        extract_outputs = output_controller.read_extract_outputs(run_id)
         text = extract_outputs.from_file("meters_and_reads.json")
         raw_meters_with_reads = [
             AclaraMeterAndRead(**json.loads(d)) for d in text.strip().split("\n")

--- a/amiadapters/adapters/aclara.py
+++ b/amiadapters/adapters/aclara.py
@@ -83,7 +83,7 @@ class AclaraAdapter(BaseAMIAdapter):
     def name(self) -> str:
         return f"aclara-{self.org_id}"
 
-    def extract(
+    def _extract(
         self,
         run_id: str,
         extract_range_start: datetime,
@@ -118,10 +118,7 @@ class AclaraAdapter(BaseAMIAdapter):
                 logger.info(f"Cleaning up downloaded file {f}")
                 os.remove(f)
 
-        self.output_controller.write_extract_outputs(
-            run_id,
-            ExtractOutput({"meters_and_reads.json": output}),
-        )
+        return ExtractOutput({"meters_and_reads.json": output})
 
     def _download_meter_and_read_files_for_date_range(
         self,
@@ -158,19 +155,12 @@ class AclaraAdapter(BaseAMIAdapter):
                     meter_and_read = AclaraMeterAndRead(**data)
                     yield json.dumps(meter_and_read, cls=DataclassJSONEncoder)
 
-    def transform(self, run_id: str):
-        extract_outputs = self.output_controller.read_extract_outputs(run_id)
+    def _transform(self, run_id: str, extract_outputs: ExtractOutput):
         text = extract_outputs.from_file("meters_and_reads.json")
         raw_meters_with_reads = [
             AclaraMeterAndRead(**json.loads(d)) for d in text.strip().split("\n")
         ]
-
-        transformed_meters, transformed_reads = self._transform_meters_and_reads(
-            raw_meters_with_reads
-        )
-
-        self.output_controller.write_transformed_meters(run_id, transformed_meters)
-        self.output_controller.write_transformed_meter_reads(run_id, transformed_reads)
+        return self._transform_meters_and_reads(raw_meters_with_reads)
 
     def _transform_meters_and_reads(
         self, raw_meters_with_reads: List[AclaraMeterAndRead]

--- a/amiadapters/adapters/beacon.py
+++ b/amiadapters/adapters/beacon.py
@@ -13,7 +13,7 @@ import requests
 
 from amiadapters.adapters.base import BaseAMIAdapter
 from amiadapters.models import DataclassJSONEncoder, GeneralMeter, GeneralMeterRead
-from amiadapters.outputs.base import BaseTaskOutputController, ExtractOutput
+from amiadapters.outputs.base import ExtractOutput
 from amiadapters.storage.snowflake import RawSnowflakeLoader
 
 logger = logging.getLogger(__name__)
@@ -390,10 +390,9 @@ class BeaconRawSnowflakeLoader(RawSnowflakeLoader):
         run_id: str,
         org_id: str,
         org_timezone: DstTzInfo,
-        output_controller: BaseTaskOutputController,
+        extract_outputs: ExtractOutput,
         snowflake_conn,
     ):
-        extract_outputs = output_controller.read_extract_outputs(run_id)
         text = extract_outputs.from_file("meters_and_reads.json")
         raw_meters_with_reads = [
             Beacon360MeterAndRead(**json.loads(d)) for d in text.strip().split("\n")

--- a/amiadapters/adapters/beacon.py
+++ b/amiadapters/adapters/beacon.py
@@ -114,7 +114,7 @@ class Beacon360Adapter(BaseAMIAdapter):
     def name(self) -> str:
         return f"beacon-360-{self.org_id}"
 
-    def extract(
+    def _extract(
         self,
         run_id: str,
         extract_range_start: datetime,
@@ -125,10 +125,7 @@ class Beacon360Adapter(BaseAMIAdapter):
             extract_range_start, extract_range_end, device_ids=device_ids
         )
         logger.info("Fetched report")
-        self.output_controller.write_extract_outputs(
-            run_id,
-            ExtractOutput({"meters_and_reads.json": self._report_to_output(report)}),
-        )
+        return ExtractOutput({"meters_and_reads.json": self._report_to_output(report)})
 
     def _report_to_output(self, report: str):
         return "\n".join(self._report_to_output_stream(report))
@@ -311,19 +308,12 @@ class Beacon360Adapter(BaseAMIAdapter):
             f.write(report)
         logger.info(f"Cached report contents at {cache_file}")
 
-    def transform(self, run_id: str):
-        extract_outputs = self.output_controller.read_extract_outputs(run_id)
+    def _transform(self, run_id: str, extract_outputs: ExtractOutput):
         text = extract_outputs.from_file("meters_and_reads.json")
         raw_meters_with_reads = [
             Beacon360MeterAndRead(**json.loads(d)) for d in text.strip().split("\n")
         ]
-
-        transformed_meters, transformed_reads = self._transform_meters_and_reads(
-            raw_meters_with_reads
-        )
-
-        self.output_controller.write_transformed_meters(run_id, transformed_meters)
-        self.output_controller.write_transformed_meter_reads(run_id, transformed_reads)
+        return self._transform_meters_and_reads(raw_meters_with_reads)
 
     def _transform_meters_and_reads(
         self, raw_meters_with_reads: List[Beacon360MeterAndRead]

--- a/amiadapters/adapters/sentryx.py
+++ b/amiadapters/adapters/sentryx.py
@@ -174,7 +174,7 @@ class SentryxAdapter(BaseAMIAdapter):
     def name(self) -> str:
         return f"sentryx-api-{self.org_id}"
 
-    def extract(
+    def _extract(
         self,
         run_id: str,
         extract_range_start: datetime,
@@ -188,19 +188,15 @@ class SentryxAdapter(BaseAMIAdapter):
         meters_with_reads = self._extract_consumption_for_all_meters(
             extract_range_start, extract_range_end
         )
-        self.output_controller.write_extract_outputs(
-            run_id,
-            ExtractOutput(
-                {
-                    "meters.json": "\n".join(
-                        json.dumps(m, cls=DataclassJSONEncoder) for m in meters
-                    ),
-                    "reads.json": "\n".join(
-                        json.dumps(m, cls=DataclassJSONEncoder)
-                        for m in meters_with_reads
-                    ),
-                }
-            ),
+        return ExtractOutput(
+            {
+                "meters.json": "\n".join(
+                    json.dumps(m, cls=DataclassJSONEncoder) for m in meters
+                ),
+                "reads.json": "\n".join(
+                    json.dumps(m, cls=DataclassJSONEncoder) for m in meters_with_reads
+                ),
+            }
         )
 
     def _extract_all_meters(self) -> List[SentryxMeter]:
@@ -300,9 +296,7 @@ class SentryxAdapter(BaseAMIAdapter):
 
         return meters
 
-    def transform(self, run_id: str):
-        extract_outputs = self.output_controller.read_extract_outputs(run_id)
-
+    def _transform(self, run_id: str, extract_outputs: ExtractOutput):
         raw_meter_text = extract_outputs.from_file("meters.json")
         raw_meters = [
             SentryxMeter(**json.loads(d)) for d in raw_meter_text.strip().split("\n")
@@ -314,12 +308,7 @@ class SentryxAdapter(BaseAMIAdapter):
             for d in raw_meters_with_reads_text.strip().split("\n")
         ]
 
-        transformed_meters, transformed_reads = self._transform_meters_and_reads(
-            raw_meters, raw_meters_with_reads
-        )
-
-        self.output_controller.write_transformed_meters(run_id, transformed_meters)
-        self.output_controller.write_transformed_meter_reads(run_id, transformed_reads)
+        return self._transform_meters_and_reads(raw_meters, raw_meters_with_reads)
 
     def _transform_meters_and_reads(
         self,

--- a/amiadapters/adapters/sentryx.py
+++ b/amiadapters/adapters/sentryx.py
@@ -13,7 +13,7 @@ from amiadapters.models import (
     GeneralMeterRead,
 )
 from amiadapters.adapters.base import BaseAMIAdapter
-from amiadapters.outputs.base import BaseTaskOutputController, ExtractOutput
+from amiadapters.outputs.base import ExtractOutput
 from amiadapters.storage.snowflake import RawSnowflakeLoader
 
 logger = logging.getLogger(__name__)
@@ -375,10 +375,9 @@ class SentryxRawSnowflakeLoader(RawSnowflakeLoader):
         run_id: str,
         org_id: str,
         org_timezone: DstTzInfo,
-        output_controller: BaseTaskOutputController,
+        extract_outputs: ExtractOutput,
         snowflake_conn,
     ):
-        extract_outputs = output_controller.read_extract_outputs(run_id)
         raw_meter_text = extract_outputs.from_file("meters.json")
         raw_meters = [
             SentryxMeter(**json.loads(d)) for d in raw_meter_text.strip().split("\n")

--- a/amiadapters/run.py
+++ b/amiadapters/run.py
@@ -27,14 +27,14 @@ def run_pipeline(
             extract_range_start, extract_range_end, backfill_params=backfill
         )
         logger.info(f"Extracting data for {adapter.name()} from {start} to {end}")
-        adapter.extract(run_id, start, end)
+        adapter.extract_and_output(run_id, start, end)
         logger.info(f"Extracted data for {adapter.name()}")
 
     logger.info(f"Extracted data for {len(adapters)} adapters")
 
     for adapter in adapters:
         logger.info(f"Transforming data for {adapter.name()}")
-        adapter.transform(run_id)
+        adapter.transform_and_output(run_id)
         logger.info(f"Transformed data for {adapter.name()}")
 
     logger.info(f"Transformed data for {len(adapters)} adapters")

--- a/amiadapters/storage/base.py
+++ b/amiadapters/storage/base.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
+from typing import List
 
 from amiadapters.config import ConfiguredStorageSink
-from amiadapters.outputs.base import BaseTaskOutputController
+from amiadapters.models import GeneralMeter, GeneralMeterRead
+from amiadapters.outputs.base import ExtractOutput
 
 
 class BaseAMIStorageSink(ABC):
@@ -12,16 +14,16 @@ class BaseAMIStorageSink(ABC):
 
     def __init__(
         self,
-        output_controller: BaseTaskOutputController,
         sink_config: ConfiguredStorageSink,
     ):
-        self.output_controller = output_controller
         self.sink_config = sink_config
 
     @abstractmethod
-    def store_raw(self, run_id: str):
+    def store_raw(self, run_id: str, extract_outputs: ExtractOutput):
         pass
 
     @abstractmethod
-    def store_transformed(self, run_id: str):
+    def store_transformed(
+        self, run_id: str, meters: List[GeneralMeter], reads: List[GeneralMeterRead]
+    ):
         pass

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -55,12 +55,12 @@ def ami_control_dag_factory(
                 else None
             )
 
-            adapter.extract(run_id, start, end, device_ids=device_ids)
+            adapter.extract_and_output(run_id, start, end, device_ids=device_ids)
 
         @task()
         def transform(adapter: BaseAMIAdapter, **context):
             run_id = context["dag_run"].run_id
-            adapter.transform(run_id)
+            adapter.transform_and_output(run_id)
 
         @task()
         def load_raw(adapter: BaseAMIAdapter, **context):

--- a/test/amiadapters/storage/test_snowflake.py
+++ b/test/amiadapters/storage/test_snowflake.py
@@ -21,8 +21,7 @@ class TestSnowflakeStorageSink(BaseTestCase):
         self.conn.cursor.return_value = self.mock_cursor
         sink_config = Mock()
         sink_config.connection.return_value = self.conn
-        self.output_controller = Mock()
-        self.output_controller.read_extract_outputs.return_value = ExtractOutput(
+        self.extract_outputs = ExtractOutput(
             {
                 "meters_and_reads.json": json.dumps(
                     beacon_meter_and_read_factory(), cls=DataclassJSONEncoder
@@ -30,7 +29,6 @@ class TestSnowflakeStorageSink(BaseTestCase):
             }
         )
         self.snowflake_sink = SnowflakeStorageSink(
-            self.output_controller,
             "org-id",
             pytz.timezone("Africa/Algiers"),
             sink_config,
@@ -238,6 +236,7 @@ class TestSnowflakeStorageSink(BaseTestCase):
     def test_store_raw(self):
         self.snowflake_sink.store_raw(
             "run-id",
+            self.extract_outputs,
         )
         self.assertEqual(2, self.mock_cursor.execute.call_count)
 
@@ -245,5 +244,6 @@ class TestSnowflakeStorageSink(BaseTestCase):
         self.snowflake_sink.raw_loader = None
         self.snowflake_sink.store_raw(
             "run-id",
+            self.extract_outputs,
         )
         self.assertEqual(0, self.mock_cursor.execute.call_count)

--- a/test/amiadapters/test_beacon.py
+++ b/test/amiadapters/test_beacon.py
@@ -584,8 +584,7 @@ class TestBeaconRawSnowflakeLoader(BaseTestCase):
         self.mock_cursor = mock.Mock()
         self.conn.cursor.return_value = self.mock_cursor
         meter_and_read = beacon_meter_and_read_factory()
-        self.output_controller = mock.Mock()
-        self.output_controller.read_extract_outputs.return_value = ExtractOutput(
+        self.extract_outputs = ExtractOutput(
             {
                 "meters_and_reads.json": json.dumps(
                     meter_and_read, cls=DataclassJSONEncoder
@@ -599,7 +598,7 @@ class TestBeaconRawSnowflakeLoader(BaseTestCase):
             "run-id",
             "org-id",
             pytz.timezone("Europe/Rome"),
-            self.output_controller,
+            self.extract_outputs,
             self.conn,
         )
         self.assertEqual(2, self.mock_cursor.execute.call_count)


### PR DESCRIPTION
The base adapter class's extract, transform and load functions, since inception, have forced the implementer to handle reading and writing to/from the intermediate storage (S3, local file system). That had two disadvantages:
1. Unit testing these functions would require unsightly mocks for the intermediate storage read/writes
2. The intermediate storage read/writes were copy/pasted across each adapter

This refactors the abstract functions so that they're behind a facade which takes care of the intermediate output read/writes.

No functional changes.