### PR TITLE
Remove device_ids filter from extract interface

### DIFF
--- a/amiadapters/adapters/aclara.py
+++ b/amiadapters/adapters/aclara.py
@@ -88,7 +88,6 @@ class AclaraAdapter(BaseAMIAdapter):
         run_id: str,
         extract_range_start: datetime,
         extract_range_end: datetime,
-        device_ids: List[str] = None,
     ):
         logging.info(
             f"Connecting to Aclara SFTP for data between {extract_range_start} and {extract_range_end}"

--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -60,15 +60,12 @@ class BaseAMIAdapter(ABC):
         run_id: str,
         extract_range_start: datetime,
         extract_range_end: datetime,
-        device_ids: List[str] = None,
     ):
         """
         Public function for extract stage.
         """
         # Use adapter implementation to extract data
-        extracted_output = self._extract(
-            run_id, extract_range_start, extract_range_end, device_ids
-        )
+        extracted_output = self._extract(run_id, extract_range_start, extract_range_end)
         # Output to intermediate storage, e.g. S3 or local files
         self.output_controller.write_extract_outputs(run_id, extracted_output)
 
@@ -78,7 +75,6 @@ class BaseAMIAdapter(ABC):
         run_id: str,
         extract_range_start: datetime,
         extract_range_end: datetime,
-        device_ids: List[str] = None,
     ) -> ExtractOutput:
         """
         Extract data from an AMI data source as defined by the implementing adapter.
@@ -86,7 +82,6 @@ class BaseAMIAdapter(ABC):
         :run_id: identifier for this run of the pipeline, is used to store intermediate output files
         :extract_range_start datetime:  start of meter read datetime range for which we'll extract data
         :extract_range_end datetime:    end of meter read datetime range for which we'll extract data
-        :device_ids optional list[str]: list of devices for which we'll extract
         :return: ExtractOutput instance that defines name and contents of extracted outputs
         """
         pass

--- a/amiadapters/adapters/beacon.py
+++ b/amiadapters/adapters/beacon.py
@@ -119,10 +119,10 @@ class Beacon360Adapter(BaseAMIAdapter):
         run_id: str,
         extract_range_start: datetime,
         extract_range_end: datetime,
-        device_ids: List[str] = None,
     ):
         report = self._fetch_range_report(
-            extract_range_start, extract_range_end, device_ids=device_ids
+            extract_range_start,
+            extract_range_end,
         )
         logger.info("Fetched report")
         return ExtractOutput({"meters_and_reads.json": self._report_to_output(report)})
@@ -140,7 +140,6 @@ class Beacon360Adapter(BaseAMIAdapter):
         self,
         extract_range_start: datetime,
         extract_range_end: datetime,
-        device_ids: List[str] = None,
     ) -> str:
         """
         Return range report as CSV string, first line with headers.
@@ -168,8 +167,6 @@ class Beacon360Adapter(BaseAMIAdapter):
             "Header_Columns": ",".join(REQUESTED_COLUMNS),
             "Has_Endpoint": True,
         }
-        if device_ids:
-            params["Meter_ID"] = ",".join(device_ids)
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
 

--- a/amiadapters/adapters/metersense.py
+++ b/amiadapters/adapters/metersense.py
@@ -182,7 +182,6 @@ class MetersenseAdapter(BaseAMIAdapter):
         run_id: str,
         extract_range_start: datetime,
         extract_range_end: datetime,
-        device_ids: List[str] = None,
     ):
         with sshtunnel.open_tunnel(
             (self.ssh_tunnel_server_host),

--- a/amiadapters/adapters/sentryx.py
+++ b/amiadapters/adapters/sentryx.py
@@ -179,7 +179,6 @@ class SentryxAdapter(BaseAMIAdapter):
         run_id: str,
         extract_range_start: datetime,
         extract_range_end: datetime,
-        device_ids: List[str] = None,
     ):
         logger.info(
             f"Extracting {self.org_id} data from {extract_range_start} to {extract_range_end}"

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -48,14 +48,7 @@ def ami_control_dag_factory(
             start, end = adapter.calculate_extract_range(
                 start_from_params, end_from_params, backfill_params=backfill_params
             )
-
-            device_ids = (
-                context["params"]["device_ids"].split(",")
-                if "device_ids" in context["params"]
-                else None
-            )
-
-            adapter.extract_and_output(run_id, start, end, device_ids=device_ids)
+            adapter.extract_and_output(run_id, start, end)
 
         @task()
         def transform(adapter: BaseAMIAdapter, **context):
@@ -114,11 +107,6 @@ for adapter in utility_adapters:
         "extract_range_end": Param(
             type="string",
             description="End of date range for which we'll extract meter read data",
-            default="",
-        ),
-        "device_ids": Param(
-            type="string",
-            description="Comma separated list of device_ids for which we'll extract meter read data",
             default="",
         ),
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi==2025.1.31
 charset-normalizer==3.4.1
 idna==3.10
 requests==2.32.4
-urllib3==2.3.0
+urllib3==2.5.0
 black==25.1.0
 PyYAML==6.0.2
 boto3==1.38.5

--- a/test/amiadapters/test_beacon.py
+++ b/test/amiadapters/test_beacon.py
@@ -235,29 +235,6 @@ class TestBeacon360Adapter(BaseTestCase):
     @mock.patch(
         "requests.get",
         side_effect=[
-            mocked_get_range_report_status_finished(),
-            mocked_get_report_from_link(text=report_csv),
-        ],
-    )
-    @mock.patch("requests.post", side_effect=[mocked_create_range_report()])
-    @mock.patch("time.sleep")
-    def test_fetch_range_report__can_filter_to_meter_ids(
-        self, mock_sleep, mock_post, mock_get
-    ):
-        self.adapter._fetch_range_report(
-            self.range_start, self.range_end, device_ids=["m1", "m2"]
-        )
-
-        self.assertEqual(1, len(mock_post.call_args_list))
-        generate_report_request = mock_post.call_args_list[0]
-        self.assertEqual(
-            "m1,m2",
-            generate_report_request.kwargs["params"]["Meter_ID"],
-        )
-
-    @mock.patch(
-        "requests.get",
-        side_effect=[
             mocked_get_range_report_status_not_finished(),
             mocked_get_range_report_status_finished(),
             mocked_get_report_from_link(text=report_csv),


### PR DESCRIPTION
The device_ids filter was added for our one-time Beacon backfill last week. This removes it so it doesn't confuse anybody down the road.

Also bumps urllib dependency to address a vulnerability.