### PR TITLE
Beacon splits account ID on hyphen

### DIFF
--- a/amiadapters/adapters/beacon.py
+++ b/amiadapters/adapters/beacon.py
@@ -319,6 +319,11 @@ class Beacon360Adapter(BaseAMIAdapter):
         transformed_reads_by_key = {}
         for meter_and_read in raw_meters_with_reads:
             account_id = meter_and_read.Account_ID
+            if account_id is not None:
+                # Some utilities combine account and location ID in the Account_ID field, and we only
+                # want the first part. If there's ever a utility with a "-" in this field that we want to
+                # keep, we'll need to revisit this solution.
+                account_id = account_id.split("-")[0]
             location_id = meter_and_read.Location_ID
             device_id = meter_and_read.Endpoint_SN
 

--- a/test/amiadapters/test_beacon.py
+++ b/test/amiadapters/test_beacon.py
@@ -521,6 +521,16 @@ class TestBeacon360Adapter(BaseTestCase):
         )
         self.assertEqual(1, len(transformed_reads))
 
+    def test_transform_meters_and_reads__splits_account_id(self):
+        raw_meters_with_reads = [
+            beacon_meter_and_read_factory(account_id="first-second"),
+        ]
+        transformed_meters, _ = self.adapter._transform_meters_and_reads(
+            raw_meters_with_reads
+        )
+        self.assertEqual(1, len(transformed_meters))
+        self.assertEqual("first", transformed_meters[0].account_id)
+
     def test_transform_meters_and_reads__ignores_reads_when_date_missing(self):
         raw_meters_with_reads = [
             beacon_meter_and_read_factory(flow_time=None),


### PR DESCRIPTION
One utility's Beacon data is coming to us with an Account ID that's in the form `<account_id>-<location_id>`. We want it to just be `account_id`, so this splits the value on `-` and takes the first.

Unfortunately this isn't the behavior across all utilities that use Beacon. It's not ideal to make utility-specific adjustments in the adapter code like this. Someday a utility may have hyphens in their `Account_ID` that they want to preserve. We'll have to revisit this solution if that happens - for now it's a quick fix to help today's users.

I'll deploy this and backfill via SQL.