### PR TITLE
All adapters transform readings to CCF; Speed up unit tests

### DIFF
--- a/amiadapters/adapters/aclara.py
+++ b/amiadapters/adapters/aclara.py
@@ -128,7 +128,8 @@ class AclaraAdapter(BaseAMIAdapter):
         downloaded_files = []
         # Get the list of remote files
         all_files_on_server = sftp.listdir(self.sftp_meter_and_reads_folder)
-        # NOTE: the files often contain readings from 1-2 days before the date in their filename. We've chosen to include those readings in the extract.
+        # NOTE: the files often contain readings from 1-2 days before the date in their filename.
+        # We've chosen to include those readings in the extract.
         files_to_download = files_for_date_range(
             all_files_on_server, extract_range_start, extract_range_end
         )
@@ -219,10 +220,14 @@ class AclaraAdapter(BaseAMIAdapter):
             transformed_meters_by_device_id[device_id] = meter
 
             flowtime = self.datetime_from_iso_str(meter_and_read.ReadingTime, pytz.UTC)
+
             register_value = (
                 float(meter_and_read.ScaledRead)
                 if meter_and_read.ScaledRead != "ERROR"
                 else None
+            )
+            register_value, register_unit = self.map_reading(
+                register_value, GeneralMeterUnitOfMeasure.CUBIC_FEET
             )
 
             read = GeneralMeterRead(
@@ -232,7 +237,7 @@ class AclaraAdapter(BaseAMIAdapter):
                 location_id=None,
                 flowtime=flowtime,
                 register_value=register_value,
-                register_unit=GeneralMeterUnitOfMeasure.CUBIC_FEET,
+                register_unit=register_unit,
                 interval_value=None,
                 interval_unit=None,
             )

--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -240,6 +240,30 @@ class BaseAMIAdapter(ABC):
             logging.info(f"Unable to map unit of measure: {unit_of_measure}")
         return result
 
+    def map_reading(
+        self, reading: float, original_unit_of_measure: str
+    ) -> Tuple[float, str]:
+        """
+        All readings values should be mapped to CCF.
+        """
+        if reading is None or original_unit_of_measure is None:
+            return reading, original_unit_of_measure
+
+        multiplier = 1
+        match original_unit_of_measure:
+            case GeneralMeterUnitOfMeasure.HUNDRED_CUBIC_FEET:
+                multiplier = 1
+            case GeneralMeterUnitOfMeasure.CUBIC_FEET:
+                multiplier = 0.01
+            case GeneralMeterUnitOfMeasure.GALLON:
+                multiplier = 0.00133680546  # 1 / 748.052
+            case _:
+                raise ValueError(
+                    f"Unrecognized unit of measure: {original_unit_of_measure}"
+                )
+
+        return reading * multiplier, GeneralMeterUnitOfMeasure.HUNDRED_CUBIC_FEET
+
     def _validate_extract_range(
         self, extract_range_start: datetime, extract_range_end: datetime
     ):

--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -262,7 +262,11 @@ class BaseAMIAdapter(ABC):
                     f"Unrecognized unit of measure: {original_unit_of_measure}"
                 )
 
-        return reading * multiplier, GeneralMeterUnitOfMeasure.HUNDRED_CUBIC_FEET
+        # 8 was picked arbitrarily, a balance between our Gallon multiplier and a precision
+        # that reflects increases in a fraction of a gallon
+        value = round(reading * multiplier, 8)
+
+        return value, GeneralMeterUnitOfMeasure.HUNDRED_CUBIC_FEET
 
     def _validate_extract_range(
         self, extract_range_start: datetime, extract_range_end: datetime

--- a/amiadapters/adapters/beacon.py
+++ b/amiadapters/adapters/beacon.py
@@ -357,14 +357,19 @@ class Beacon360Adapter(BaseAMIAdapter):
                 )
                 continue
 
+            register_value, register_unit = self.map_reading(
+                float(meter_and_read.Read),
+                meter_and_read.Read_Unit,  # Expected to always be CCF
+            )
+
             read = GeneralMeterRead(
                 org_id=self.org_id,
                 device_id=device_id,
                 account_id=account_id,
                 location_id=location_id,
                 flowtime=flowtime,
-                register_value=float(meter_and_read.Read),
-                register_unit=self.map_unit_of_measure(meter_and_read.Read_Unit),
+                register_value=register_value,
+                register_unit=register_unit,
                 interval_value=None,
                 interval_unit=None,
             )

--- a/amiadapters/adapters/metersense.py
+++ b/amiadapters/adapters/metersense.py
@@ -542,6 +542,11 @@ class MetersenseAdapter(BaseAMIAdapter):
                 accounts_by_location_id,
             )
 
+            interval_value, interval_unit = self.map_reading(
+                raw_interval_read.read_value,
+                raw_interval_read.uom,  # Expected to be CCF
+            )
+
             read = GeneralMeterRead(
                 org_id=self.org_id,
                 device_id=device_id,
@@ -550,8 +555,8 @@ class MetersenseAdapter(BaseAMIAdapter):
                 flowtime=flowtime,
                 register_value=None,
                 register_unit=None,
-                interval_value=raw_interval_read.read_value,
-                interval_unit=self.map_unit_of_measure(raw_interval_read.uom),
+                interval_value=interval_value,
+                interval_unit=interval_unit,
             )
             reads_by_device_and_time[key] = read
 
@@ -563,6 +568,10 @@ class MetersenseAdapter(BaseAMIAdapter):
             flowtime = self.datetime_from_iso_str(
                 raw_register_read.read_dtm, self.org_timezone
             )
+            register_value, register_unit = self.map_reading(
+                raw_register_read.read_value,
+                raw_register_read.uom,  # Expected to be CCF
+            )
             key = (
                 device_id,
                 flowtime,
@@ -572,13 +581,13 @@ class MetersenseAdapter(BaseAMIAdapter):
                 old_read = reads_by_device_and_time[key]
                 read = replace(
                     old_read,
-                    register_value=raw_register_read.read_value,
-                    register_unit=self.map_unit_of_measure(raw_register_read.uom),
+                    register_value=register_value,
+                    register_unit=register_unit,
                 )
             else:
                 account_id, location_id = self._get_account_and_location_for_read(
-                    raw_interval_read.meter_id,
-                    raw_interval_read.read_dtm,
+                    raw_register_read.meter_id,
+                    raw_register_read.read_dtm,
                     xrefs_by_meter_id,
                     accounts_by_location_id,
                 )
@@ -588,8 +597,8 @@ class MetersenseAdapter(BaseAMIAdapter):
                     account_id=account_id,
                     location_id=location_id,
                     flowtime=flowtime,
-                    register_value=raw_register_read.read_value,
-                    register_unit=self.map_unit_of_measure(raw_register_read.uom),
+                    register_value=register_value,
+                    register_unit=register_unit,
                     interval_value=None,
                     interval_unit=None,
                 )

--- a/amiadapters/adapters/sentryx.py
+++ b/amiadapters/adapters/sentryx.py
@@ -345,7 +345,10 @@ class SentryxAdapter(BaseAMIAdapter):
                 meter_metadata.account_id if meter_metadata is not None else None
             )
             for raw_read in raw_meter.data:
-                value = raw_read.reading
+                register_value, register_unit = self.map_reading(
+                    raw_read.reading,
+                    raw_meter.units,  # Expected to be CF
+                )
                 read = GeneralMeterRead(
                     org_id=self.org_id,
                     device_id=device_id,
@@ -354,8 +357,8 @@ class SentryxAdapter(BaseAMIAdapter):
                     flowtime=self.datetime_from_iso_str(
                         raw_read.time_stamp, self.org_timezone
                     ),
-                    register_value=value,
-                    register_unit=self.map_unit_of_measure(raw_meter.units),
+                    register_value=register_value,
+                    register_unit=register_unit,
                     interval_value=None,
                     interval_unit=None,
                 )

--- a/amiadapters/outputs/s3.py
+++ b/amiadapters/outputs/s3.py
@@ -27,6 +27,7 @@ class S3TaskOutputController(BaseTaskOutputController):
         org_id: str,
         s3_prefix: str = "intermediate_outputs",
         aws_profile_name: str = None,
+        s3_client=None,
     ):
         """
         bucket_name: S3 bucket to use
@@ -34,6 +35,7 @@ class S3TaskOutputController(BaseTaskOutputController):
         s3_prefix: optional S3 prefix (acts like a root folder inside the bucket)
         aws_profile_name: optional profile name used to locate credentials. Meant for local development, not for prod.
                           Prod should use IAM role we configure with Terraform.
+        s3_client: optionally pass in S3 client instead of creating it here. Meant for testing
         """
         if not bucket_name or not org_id:
             raise Exception(
@@ -43,11 +45,14 @@ class S3TaskOutputController(BaseTaskOutputController):
         self.bucket_name = bucket_name
         self.org_id = org_id
         self.s3_prefix = s3_prefix.strip("/")
-        if aws_profile_name:
-            session = boto3.Session(profile_name=aws_profile_name)
-            self.s3 = session.client("s3")
+        if s3_client is None:
+            if aws_profile_name:
+                session = boto3.Session(profile_name=aws_profile_name)
+                self.s3 = session.client("s3")
+            else:
+                self.s3 = boto3.client("s3")
         else:
-            self.s3 = boto3.client("s3")
+            self.s3 = s3_client
 
     def write_extract_outputs(self, run_id: str, outputs: ExtractOutput):
         for name, content in outputs.get_outputs().items():

--- a/test/amiadapters/outputs/test_s3.py
+++ b/test/amiadapters/outputs/test_s3.py
@@ -17,12 +17,13 @@ class TestS3TaskOutputController(BaseTestCase):
         self.bucket = "test-bucket"
         self.org_id = "org-abc"
         self.prefix = "my-prefix"
-        self.controller = S3TaskOutputController(
-            bucket_name=self.bucket, org_id=self.org_id, s3_prefix=self.prefix
-        )
-
         self.mock_s3 = MagicMock()
-        self.controller.s3 = self.mock_s3  # Inject mock S3 client
+        self.controller = S3TaskOutputController(
+            bucket_name=self.bucket,
+            org_id=self.org_id,
+            s3_prefix=self.prefix,
+            s3_client=self.mock_s3,
+        )
 
     def test_write_extract_outputs(self):
         outputs = ExtractOutput({"file1.txt": "data1", "file2.txt": "data2"})

--- a/test/amiadapters/test_aclara.py
+++ b/test/amiadapters/test_aclara.py
@@ -155,7 +155,8 @@ class TestAclaraAdapter(BaseTestCase):
         self.assertEqual(meter.endpoint_id, "2")
         self.assertEqual(meter.meter_size, "0.625x0.75")
         self.assertEqual(read.device_id, "1")
-        self.assertEqual(read.register_value, 23497.071)
+        self.assertEqual(read.register_value, 234.97071)
+        self.assertEqual(read.register_unit, "CCF")
 
     def test_deduplicates_during_transform(self):
         input_data = [self.meter_and_read_factory(), self.meter_and_read_factory()]

--- a/test/amiadapters/test_base.py
+++ b/test/amiadapters/test_base.py
@@ -90,6 +90,40 @@ class TestBaseAdapter(BaseTestCase):
             # End after start
             self.adapter._validate_extract_range(self.range_end, self.range_start)
 
+    def test_map_reading__valid_ccf_conversion(self):
+        value, unit = self.adapter.map_reading(12.5, "CCF")
+        self.assertEqual(value, 12.5)
+        self.assertEqual(unit, "CCF")
+
+    def test_map_reading__valid_cf_conversion(self):
+        value, unit = self.adapter.map_reading(1200, "CF")
+        self.assertEqual(value, 12.0)
+        self.assertEqual(unit, "CCF")
+
+    def test_map_reading__valid_gal_conversion(self):
+        value, unit = self.adapter.map_reading(2000, "Gallon")
+        self.assertAlmostEqual(value, 2.674, delta=0.001)
+        self.assertEqual(unit, "CCF")
+
+    def test_map_reading__none_reading(self):
+        value, unit = self.adapter.map_reading(None, "CCF")
+        self.assertIsNone(value)
+        self.assertEqual(unit, "CCF")
+
+    def test_map_reading__none_unit(self):
+        value, unit = self.adapter.map_reading(10.0, None)
+        self.assertEqual(value, 10.0)
+        self.assertIsNone(unit)
+
+    def test_map_reading__none_both(self):
+        value, unit = self.adapter.map_reading(None, None)
+        self.assertIsNone(value)
+        self.assertIsNone(unit)
+
+    def test_map_reading__unrecognized_unit(self):
+        with self.assertRaises(ValueError, msg="Unrecognized unit of measure: Pounds"):
+            self.adapter.map_reading(5.0, "Pounds")
+
 
 class TestExtractRangeCalculator(BaseTestCase):
 

--- a/test/amiadapters/test_beacon.py
+++ b/test/amiadapters/test_beacon.py
@@ -160,19 +160,6 @@ class TestBeacon360Adapter(BaseTestCase):
         self.assertEqual(0, mock_get.call_count)
         self.assertEqual(0, mock_post.call_count)
 
-    def test_fetch_range_report__throws_exception_when_range_not_valid(
-        self,
-    ):
-        with self.assertRaises(Exception) as context:
-            self.adapter._fetch_range_report(None, self.range_end)
-
-        with self.assertRaises(Exception) as context:
-            self.adapter._fetch_range_report(self.range_start, None)
-
-        with self.assertRaises(Exception) as context:
-            # End after start
-            self.adapter._fetch_range_report(self.range_end, self.range_start)
-
     @mock.patch(
         "requests.get",
         side_effect=[

--- a/test/amiadapters/test_sentryx.py
+++ b/test/amiadapters/test_sentryx.py
@@ -342,8 +342,8 @@ class TestSentryxAdapter(BaseTestCase):
                 flowtime=datetime.datetime(
                     2024, 7, 7, 1, 0, tzinfo=pytz.timezone("Africa/Algiers")
                 ),
-                register_value=116233.61,
-                register_unit="CF",
+                register_value=1162.3361,
+                register_unit="CCF",
                 interval_value=None,
                 interval_unit=None,
             ),
@@ -355,8 +355,8 @@ class TestSentryxAdapter(BaseTestCase):
                 flowtime=datetime.datetime(
                     2024, 7, 7, 1, 0, tzinfo=pytz.timezone("Africa/Algiers")
                 ),
-                register_value=11,
-                register_unit="CF",
+                register_value=0.11,
+                register_unit="CCF",
                 interval_value=None,
                 interval_unit=None,
             ),


### PR DESCRIPTION
We'd like to standardize meter reading units to CCF in the readings table. This updates all transform code to do that conversion. There will be an accompanying backfill in the databases.

This also includes two small unit test updates that speed things up - we were accidentally hitting external networks in the tests.