### PR TITLE
Map KGAL and Gallons to CCF

### DIFF
--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -225,21 +225,6 @@ class BaseAMIAdapter(ABC):
             logging.info(f"Unable to map meter size: {size}")
         return result
 
-    def map_unit_of_measure(self, unit_of_measure: str) -> str:
-        """
-        Map an AMI data provider meter read's unit of measure to one
-        of our generalized values. Return None if it can't be mapped.
-        """
-        mapping = {
-            "CF": GeneralMeterUnitOfMeasure.CUBIC_FEET,
-            "CCF": GeneralMeterUnitOfMeasure.HUNDRED_CUBIC_FEET,
-            "Gallon": GeneralMeterUnitOfMeasure.GALLON,
-        }
-        result = mapping.get(unit_of_measure)
-        if result is None:
-            logging.info(f"Unable to map unit of measure: {unit_of_measure}")
-        return result
-
     def map_reading(
         self, reading: float, original_unit_of_measure: str
     ) -> Tuple[float, str]:
@@ -258,8 +243,10 @@ class BaseAMIAdapter(ABC):
                 multiplier = 1
             case GeneralMeterUnitOfMeasure.CUBIC_FEET:
                 multiplier = 0.01
-            case GeneralMeterUnitOfMeasure.GALLON:
+            case GeneralMeterUnitOfMeasure.GALLON | GeneralMeterUnitOfMeasure.GALLONS:
                 multiplier = 0.00133680546  # 1 / 748.052
+            case GeneralMeterUnitOfMeasure.KILO_GALLON:
+                multiplier = 1.33680546  # 1000 * 1 / 748.052
             case _:
                 raise ValueError(
                     f"Unrecognized unit of measure: {original_unit_of_measure}"
@@ -334,13 +321,14 @@ class BaseAMIAdapter(ABC):
 
 class GeneralMeterUnitOfMeasure:
     """
-    Normalized values for a meter's unit of measure. All AMI-provided
-    values should be mapped to one of these.
+    Normalized values for a meter's unit of measure.
     """
 
     CUBIC_FEET = "CF"
     HUNDRED_CUBIC_FEET = "CCF"
     GALLON = "Gallon"
+    GALLONS = "Gallons"
+    KILO_GALLON = "KGAL"
 
 
 class ExtractRangeCalculator:

--- a/amiadapters/adapters/beacon.py
+++ b/amiadapters/adapters/beacon.py
@@ -359,7 +359,7 @@ class Beacon360Adapter(BaseAMIAdapter):
 
             register_value, register_unit = self.map_reading(
                 float(meter_and_read.Read),
-                meter_and_read.Read_Unit,  # Expected to always be CCF
+                meter_and_read.Read_Unit,  # Expected to be CCF or KGAL
             )
 
             read = GeneralMeterRead(

--- a/test/amiadapters/test_base.py
+++ b/test/amiadapters/test_base.py
@@ -66,17 +66,6 @@ class TestBaseAdapter(BaseTestCase):
             result = self.adapter.map_meter_size(size)
             self.assertEqual(result, expected)
 
-    def test_unit_of_measure(self):
-        cases = [
-            ("CF", "CF"),
-            ("CCF", "CCF"),
-            ("Gallon", "Gallon"),
-            (None, None),
-        ]
-        for size, expected in cases:
-            result = self.adapter.map_unit_of_measure(size)
-            self.assertEqual(result, expected)
-
     def test_extract_consumption_for_all_meters__throws_exception_when_range_not_valid(
         self,
     ):
@@ -103,6 +92,16 @@ class TestBaseAdapter(BaseTestCase):
     def test_map_reading__valid_gal_conversion(self):
         value, unit = self.adapter.map_reading(2000, "Gallon")
         self.assertAlmostEqual(value, 2.674, delta=0.001)
+        self.assertEqual(unit, "CCF")
+
+    def test_map_reading__valid_gals_conversion(self):
+        value, unit = self.adapter.map_reading(2000, "Gallons")
+        self.assertAlmostEqual(value, 2.674, delta=0.001)
+        self.assertEqual(unit, "CCF")
+
+    def test_map_reading__valid_kgal_conversion(self):
+        value, unit = self.adapter.map_reading(5, "KGAL")
+        self.assertAlmostEqual(value, 6.684, delta=0.001)
         self.assertEqual(unit, "CCF")
 
     def test_map_reading__none_reading(self):


### PR DESCRIPTION
Found two more units of measure that we haven't mapped yet. Also removed a now-unused function.