### PR TITLE
sshtunnel library finds free port for tunnel connection

### DIFF
--- a/amiadapters/adapters/connections.py
+++ b/amiadapters/adapters/connections.py
@@ -1,0 +1,28 @@
+import logging
+
+import sshtunnel
+
+logger = logging.getLogger(__name__)
+
+
+def open_ssh_tunnel(
+    ssh_tunnel_server_host: str,
+    ssh_tunnel_username: str,
+    ssh_tunnel_key_path: str,
+    remote_host: str,
+    remote_port: str,
+):
+    """
+    Utility function for opening an SSH tunnel connection.
+    """
+    return sshtunnel.open_tunnel(
+        (ssh_tunnel_server_host),
+        ssh_username=ssh_tunnel_username,
+        ssh_pkey=ssh_tunnel_key_path,
+        remote_bind_address=(remote_host, remote_port),
+        # Locally, bind to localhost and arbitrary port.
+        # Use same host and port later when connecting to Redshift.
+        # Using port "0" will automatically choose a free port. Access
+        # it with the local_bind_port property of this returned context.
+        local_bind_address=("0.0.0.0", 0),
+    )


### PR DESCRIPTION
Many recent DAG failures have happened when two runs of adapters w/ SSH tunnels run simultaneously. Thanks @christophertull for quickly realizing this was because we've been using a hardcoded port on the Airflow server to create the connection 😎 This updates the code to find a free port for the SSH tunnel and should allow simultaneous DAG runs.