### PR TITLE
Finish Subeca extract and transform

### DIFF
--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -171,6 +171,7 @@ class BaseAMIAdapter(ABC):
             "0.625": "0.625",
             "5/8in": "0.625",
             '5/8"': "0.625",
+            "5/8": "0.625",
             "0.75": "0.75",
             "3/4": "0.75",
             "3/4in": "0.75",
@@ -208,6 +209,7 @@ class BaseAMIAdapter(ABC):
             "12.0": "12",
             '12"': "12",
             "5/8x3/4": "0.625x0.75",
+            "5/8 x 3/4": "0.625x0.75",
             "5/8x3/4in": "0.625x0.75",
             "W-TSCR3": "3",
             "W-TSC4": "4",
@@ -256,7 +258,7 @@ class BaseAMIAdapter(ABC):
             return reading, None
 
         multiplier = 1
-        match original_unit_of_measure:
+        match original_unit_of_measure.upper():
             case GeneralMeterUnitOfMeasure.CUBIC_FEET:
                 multiplier = 1
             case GeneralMeterUnitOfMeasure.HUNDRED_CUBIC_FEET:

--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -346,8 +346,8 @@ class GeneralMeterUnitOfMeasure:
 
     CUBIC_FEET = "CF"
     HUNDRED_CUBIC_FEET = "CCF"
-    GALLON = "Gallon"
-    GALLONS = "Gallons"
+    GALLON = "GALLON"
+    GALLONS = "GALLONS"
     KILO_GALLON = "KGAL"
 
 

--- a/test/amiadapters/test_subeca.py
+++ b/test/amiadapters/test_subeca.py
@@ -1,0 +1,254 @@
+import datetime
+import json
+import pytz
+from unittest.mock import MagicMock, patch
+
+from amiadapters.config import ConfiguredLocalTaskOutputController
+from amiadapters.models import GeneralMeterRead
+from amiadapters.models import GeneralMeter
+from amiadapters.outputs.base import ExtractOutput
+from amiadapters.adapters.subeca import (
+    SubecaAccount,
+    SubecaAdapter,
+    SubecaReading,
+)
+
+from test.base_test_case import BaseTestCase
+
+
+def create_mock_account_metadata_response() -> MagicMock:
+    mock_account_metadata_response = MagicMock()
+    mock_account_metadata_response.ok = True
+    mock_account_metadata_response.json.return_value = {
+        "accountId": "acct1",
+        "accountStatus": "active",
+        "meterSerial": "M123",
+        "billingRoute": "BR1",
+        "registerSerial": "RS123",
+        "meterInfo": {"meterSize": "5/8"},
+        "createdAt": "2025-08-01T00:00:00+00:00",
+        "device": {
+            "deviceId": "device1",
+            "activeProtocol": "LoRaWAN",
+            "installationDate": "2025-06-05T19:33:54+00:00",
+            "latestCommunicationDate": "2025-08-05T20:19:46+00:00",
+            "latestReading": {
+                "value": "16685.9",
+                "unit": "gal",
+                "date": "2025-08-05T20:19:46+00:00",
+            },
+        },
+    }
+    return mock_account_metadata_response
+
+
+def create_mock_usages_response() -> MagicMock:
+    mock_usages_response = MagicMock()
+    mock_usages_response.ok = True
+    mock_usages_response.json.return_value = {
+        "data": {
+            "hourly": {
+                "2025-08-01T10:00:00+00:00": {
+                    "deviceId": "device1",
+                    "unit": "cf",
+                    "value": 123.4,
+                }
+            }
+        }
+    }
+    return mock_usages_response
+
+
+def create_mock_accounts_response() -> MagicMock:
+    mock_accounts_response = MagicMock()
+    mock_accounts_response.ok = True
+    mock_accounts_response.json.return_value = {
+        "data": [{"accountId": "acct1"}],
+        "nextToken": None,
+    }
+    return mock_accounts_response
+
+
+class TestSubecaAdapter(BaseTestCase):
+
+    def setUp(self):
+        self.adapter = SubecaAdapter(
+            org_id="this-utility",
+            org_timezone=pytz.timezone("Africa/Algiers"),
+            api_key="test-key",
+            configured_task_output_controller=ConfiguredLocalTaskOutputController(
+                "/tmp/output"
+            ),
+            configured_sinks=[],
+        )
+        self.start_date = datetime.datetime(2024, 1, 2, 0, 0)
+        self.end_date = datetime.datetime(2024, 1, 3, 0, 0)
+
+    def test_init(self):
+        self.assertEqual("test-key", self.adapter.api_key)
+        self.assertEqual("this-utility", self.adapter.org_id)
+        self.assertEqual(pytz.timezone("Africa/Algiers"), self.adapter.org_timezone)
+        self.assertEqual("subeca-this-utility", self.adapter.name())
+
+    @patch("amiadapters.adapters.subeca.requests.get")
+    @patch("amiadapters.adapters.subeca.requests.post")
+    def test_extract_success(self, mock_post, mock_get):
+        # --- Mock GET /accounts response ---
+        mock_accounts_response = create_mock_accounts_response()
+        mock_get.return_value = mock_accounts_response
+
+        # --- Mock POST /usages response ---
+        mock_usages_response = create_mock_usages_response()
+        mock_post.return_value = mock_usages_response
+
+        # --- Mock GET /accounts/{id} metadata response ---
+        mock_account_metadata_response = create_mock_account_metadata_response()
+        # The second GET call should return metadata response
+        mock_get.side_effect = [mock_accounts_response, mock_account_metadata_response]
+
+        result = self.adapter._extract("run1", self.start_date, self.end_date)
+
+        # Verify API calls
+        mock_get.assert_any_call(
+            f"{self.adapter.api_url}/v1/accounts",
+            params={"pageSize": 100},
+            headers={"accept": "application/json", "x-subeca-api-key": "test-key"},
+        )
+        self.assertEqual(2, mock_get.call_count)
+        mock_post.assert_called_once()
+
+        # Validate returned ExtractOutput
+        accounts = result.from_file("accounts.json").splitlines()
+        usages = result.from_file("usages.json").splitlines()
+
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(len(usages), 1)
+
+        account_data = SubecaAccount.from_json(accounts[0])
+        usage_data = SubecaReading(**json.loads(usages[0]))
+
+        self.assertEqual(account_data.accountId, "acct1")
+        self.assertEqual(account_data.latestReading.value, "16685.9")
+        self.assertEqual(usage_data.deviceId, "device1")
+
+    @patch("amiadapters.adapters.subeca.requests.get")
+    @patch("amiadapters.adapters.subeca.requests.post")
+    def test_extract_ignores_usage_with_no_device_id(self, mock_post, mock_get):
+        # --- Mock GET /accounts response ---
+        mock_accounts_response = create_mock_accounts_response()
+        mock_get.return_value = mock_accounts_response
+
+        # --- Mock POST /usages response ---
+        mock_usages_response = create_mock_usages_response()
+        mock_usages_response.json.return_value["data"]["hourly"][
+            "2025-08-01T10:00:00+00:00"
+        ] = {
+            "deviceId": "",
+            "unit": "",
+            "value": "",
+        }
+        mock_post.return_value = mock_usages_response
+
+        # --- Mock GET /accounts/{id} metadata response ---
+        mock_account_metadata_response = create_mock_account_metadata_response()
+        # The second GET call should return metadata response
+        mock_get.side_effect = [mock_accounts_response, mock_account_metadata_response]
+
+        result = self.adapter._extract("run1", self.start_date, self.end_date)
+
+        # Validate returned ExtractOutput
+        accounts = result.from_file("accounts.json").splitlines()
+        usages = result.from_file("usages.json").splitlines()
+
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(len(usages), 0)
+
+    @patch("amiadapters.adapters.subeca.requests.get")
+    @patch("amiadapters.adapters.subeca.requests.post")
+    def test_extract_can_paginate(self, mock_post, mock_get):
+        # Mock accounts
+        mock_accounts_response_1 = create_mock_accounts_response()
+        mock_accounts_response_2 = create_mock_accounts_response()
+        # Set first response up to continue pagination
+        mock_accounts_response_1.json.return_value["nextToken"] = "next"
+
+        # --- Mock POST /usages response ---
+        mock_usages_response = create_mock_usages_response()
+        mock_post.return_value = mock_usages_response
+
+        # Mock GET /accounts/{accountId}
+        mock_account_metadata_response = create_mock_account_metadata_response()
+
+        # The second GET call should return metadata response
+        mock_get.side_effect = [
+            mock_accounts_response_1,
+            mock_accounts_response_2,
+            mock_account_metadata_response,
+        ]
+
+        result = self.adapter._extract("run1", self.start_date, self.end_date)
+
+        self.assertEqual(3, mock_get.call_count)
+
+        # Validate returned ExtractOutput
+        accounts = result.from_file("accounts.json").splitlines()
+        usages = result.from_file("usages.json").splitlines()
+
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(len(usages), 1)
+
+    @patch("amiadapters.adapters.subeca.requests.get")
+    def test_extract_accounts_api_failure(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.ok = False
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_get.return_value = mock_response
+
+        with self.assertRaises(ValueError) as ctx:
+            self.adapter._extract("run1", self.start_date, self.end_date)
+
+        self.assertIn("Invalid response from accounts request", str(ctx.exception))
+
+    @patch("amiadapters.adapters.subeca.requests.get")
+    @patch("amiadapters.adapters.subeca.requests.post")
+    def test_extract_usage_api_failure(self, mock_post, mock_get):
+        mock_get.return_value = create_mock_accounts_response()
+
+        # Mock POST /usages to fail
+        mock_usage_response = MagicMock()
+        mock_usage_response.ok = False
+        mock_usage_response.status_code = 400
+        mock_usage_response.text = "Bad Request"
+        mock_post.return_value = mock_usage_response
+
+        with self.assertRaises(ValueError) as ctx:
+            self.adapter._extract("run1", self.start_date, self.end_date)
+
+        self.assertIn("Invalid response from usages endpoint", str(ctx.exception))
+
+    @patch("amiadapters.adapters.subeca.requests.get")
+    @patch("amiadapters.adapters.subeca.requests.post")
+    def test_extract_account_metadata_api_failure(self, mock_post, mock_get):
+        # Mock accounts to return 1 account
+        mock_accounts_response = create_mock_accounts_response()
+
+        # --- Mock POST /usages response ---
+        mock_usages_response = create_mock_usages_response()
+        mock_post.return_value = mock_usages_response
+
+        # Mock GET /accounts/{accountId} to fail
+        mock_account_metadata_response = MagicMock()
+        mock_account_metadata_response.ok = False
+        mock_account_metadata_response.status_code = 400
+        mock_account_metadata_response.text = "Bad Request"
+
+        # The second GET call should return metadata response
+        mock_get.side_effect = [mock_accounts_response, mock_account_metadata_response]
+
+        with self.assertRaises(ValueError) as ctx:
+            self.adapter._extract("run1", self.start_date, self.end_date)
+
+        self.assertIn(
+            "Invalid response from account metadata endpoint", str(ctx.exception)
+        )


### PR DESCRIPTION
Finishes Subeca extract by using these APIs (https://sierra-cc.api.subeca.online/docs):
- fetch all account IDs from /accounts endpoint
- hit /accounts/{accountId}/usage for each account to get its interval reads
- hit /accounts/{accountId} for each account to get its account and device metadata, plus the device's latest reading which I've tacked on as a register read

Left a couple TODOs in the transform step to check which IDs we want to use.