### PR TITLE
Ignore subeca usages when value is empty string

### DIFF
--- a/amiadapters/adapters/subeca.py
+++ b/amiadapters/adapters/subeca.py
@@ -337,23 +337,24 @@ class SubecaAdapter(BaseAMIAdapter):
             # Interval reads
             usages = raw_usages_by_device_id.get(account.deviceId, [])
             for usage in usages:
-                flowtime = datetime.fromisoformat(usage.usageTime)
-                interval_value, interval_unit = self.map_reading(
-                    float(usage.value),
-                    usage.unit,
-                )
-                read = GeneralMeterRead(
-                    org_id=self.org_id,
-                    device_id=device_id,
-                    account_id=account_id,
-                    location_id=location_id,
-                    flowtime=flowtime,
-                    register_value=None,
-                    register_unit=None,
-                    interval_value=interval_value,
-                    interval_unit=interval_unit,
-                )
-                reads_by_device_and_time[(device_id, flowtime)] = read
+                if usage.value:
+                    flowtime = datetime.fromisoformat(usage.usageTime)
+                    interval_value, interval_unit = self.map_reading(
+                        float(usage.value),
+                        usage.unit,
+                    )
+                    read = GeneralMeterRead(
+                        org_id=self.org_id,
+                        device_id=device_id,
+                        account_id=account_id,
+                        location_id=location_id,
+                        flowtime=flowtime,
+                        register_value=None,
+                        register_unit=None,
+                        interval_value=interval_value,
+                        interval_unit=interval_unit,
+                    )
+                    reads_by_device_and_time[(device_id, flowtime)] = read
 
             # Tack on register read from latest reading
             if account.latestReading and account.latestReading.value:

--- a/test/amiadapters/test_subeca.py
+++ b/test/amiadapters/test_subeca.py
@@ -293,6 +293,34 @@ class TestSubecaAdapter(BaseTestCase):
         self.assertEqual(reads[0].interval_value, 1)
         self.assertEqual(reads[0].register_value, 100)
 
+    def test_transform_when_usage_is_empty_string(self):
+        usage_time = "2025-08-01T10:00:00+00:00"
+        account = SubecaAccount(
+            accountId="A1",
+            accountStatus="active",
+            meterSerial="M1",
+            billingRoute="",
+            registerSerial="R1",
+            meterSize="5/8",
+            createdAt="2025-08-01T10:00:00+00:00",
+            deviceId="D1",
+            activeProtocol="LoRaWAN",
+            installationDate="2025-08-01T10:00:00+00:00",
+            latestCommunicationDate="2025-08-02T10:00:00+00:00",
+            latestReading=SubecaReading(
+                deviceId="D1", usageTime=usage_time, unit="cf", value="100"
+            ),
+        )
+        usage = SubecaReading(deviceId="D1", usageTime=usage_time, unit="cf", value="")
+        extract_output = self.make_extract_output([account], [usage])
+
+        meters, reads = self.adapter._transform("run-1", extract_output)
+
+        self.assertEqual(len(meters), 1)
+        self.assertEqual(len(reads), 1)  # Register read added
+        self.assertEqual(reads[0].interval_value, None)
+        self.assertEqual(reads[0].register_value, 100)
+
     def test_transform_meter_with_no_reads_is_still_included(self):
         """Meters should be included even if they have no reads."""
         account = SubecaAccount(


### PR DESCRIPTION
Fixes a type casting error by ignoring Subeca interval reads when they have a value of `''`.