### PR TITLE
Add data quality checks DAG with unique meters check

### DIFF
--- a/amiadapters/config.py
+++ b/amiadapters/config.py
@@ -416,7 +416,7 @@ class ConfiguredStorageSink:
             case _:
                 ValueError(f"Unrecognized type {self.type}")
 
-    def checks(self) -> List[str]:
+    def checks(self) -> List:
         """
         Return names of configured data quality checks for this sink.
         """

--- a/amiadapters/config.py
+++ b/amiadapters/config.py
@@ -13,10 +13,11 @@ import yaml
 
 class AMIAdapterConfiguration:
 
-    def __init__(self, sources, backfills=None, notifications=None):
+    def __init__(self, sources, backfills=None, notifications=None, sinks=None):
         self._sources = sources
         self._backfills = backfills if backfills is not None else []
         self._notifications = notifications
+        self._sinks = sinks if sinks is not None else []
 
     @classmethod
     def from_yaml(cls, config_file: str, secrets_file: str):
@@ -35,6 +36,7 @@ class AMIAdapterConfiguration:
         for sink in config_yaml.get("sinks", []):
             sink_id = sink.get("id")
             sink_type = sink.get("type")
+            checks = sink.get("checks")
             match sink_type:
                 case ConfiguredStorageSinkType.SNOWFLAKE:
                     sink_secrets_yaml = secrets_yaml.get("sinks", {}).get(sink_id, {})
@@ -50,7 +52,10 @@ class AMIAdapterConfiguration:
                         schema=sink_secrets_yaml.get("schema"),
                     )
                     sink = ConfiguredStorageSink(
-                        ConfiguredStorageSinkType.SNOWFLAKE, sink_id, sink_secrets
+                        ConfiguredStorageSinkType.SNOWFLAKE,
+                        sink_id,
+                        sink_secrets,
+                        data_quality_check_names=checks,
                     )
                 case _:
                     raise ValueError(f"Unrecognized sink type {sink_type}")
@@ -213,7 +218,10 @@ class AMIAdapterConfiguration:
             notifications = None
 
         return AMIAdapterConfiguration(
-            sources=sources, backfills=backfills, notifications=notifications
+            sources=sources,
+            backfills=backfills,
+            notifications=notifications,
+            sinks=all_sinks,
         )
 
     def adapters(self):
@@ -352,6 +360,9 @@ class AMIAdapterConfiguration:
             )
         return None
 
+    def sinks(self) -> List:
+        return self._sinks
+
     def __repr__(self):
         return f"sources=[{", ".join(str(s) for s in self._sources)}]"
 
@@ -377,10 +388,17 @@ class ConfiguredStorageSink:
     creating connections off of the configuration.
     """
 
-    def __init__(self, type: str, id: str, secrets: Union[SnowflakeSecrets]):
+    def __init__(
+        self,
+        type: str,
+        id: str,
+        secrets: Union[SnowflakeSecrets],
+        data_quality_check_names: List = None,
+    ):
         self.type = self._type(type)
         self.id = self._id(id)
         self.secrets = self._secrets(secrets)
+        self.data_quality_check_names = data_quality_check_names or []
 
     def connection(self):
         match self.type:
@@ -397,6 +415,21 @@ class ConfiguredStorageSink:
                 )
             case _:
                 ValueError(f"Unrecognized type {self.type}")
+
+    def checks(self) -> List[str]:
+        """
+        Return names of configured data quality checks for this sink.
+        """
+        from amiadapters.storage.snowflake import SnowflakeMetersUniqueByDeviceIdCheck
+
+        result = []
+        for name in self.data_quality_check_names:
+            if (
+                name == "snowflake-meters-unique-by-device-id"
+                and self.type == ConfiguredStorageSinkType.SNOWFLAKE
+            ):
+                result.append(SnowflakeMetersUniqueByDeviceIdCheck(self.connection()))
+        return result
 
     def _type(self, type: str) -> str:
         if type in {

--- a/amiadapters/storage/base.py
+++ b/amiadapters/storage/base.py
@@ -27,3 +27,27 @@ class BaseAMIStorageSink(ABC):
         self, run_id: str, meters: List[GeneralMeter], reads: List[GeneralMeterRead]
     ):
         pass
+
+
+class BaseAMIDataQualityCheck(ABC):
+    """
+    A data quality check for the data stored in this sink. A sink may have many
+    data quality checks. They're run together to ensure the data in the sink meets
+    standard assumptions we've built into our data model.
+    """
+
+    @abstractmethod
+    def name(self) -> str:
+        """
+        Name of this check, hyphenated, used to identify the check in our configuration system.
+        """
+        pass
+
+    @abstractmethod
+    def check(self) -> bool:
+        """
+        Run the check.
+
+        :return: True if check passes, else False.
+        """
+        pass

--- a/amicontrol/dags/ami_data_quality_checks_dag.py
+++ b/amicontrol/dags/ami_data_quality_checks_dag.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from airflow.decorators import dag, task
+
+from amiadapters.config import (
+    AMIAdapterConfiguration,
+    find_config_yaml,
+    find_secrets_yaml,
+)
+
+from amiadapters.storage.base import BaseAMIDataQualityCheck
+
+config = AMIAdapterConfiguration.from_yaml(find_config_yaml(), find_secrets_yaml())
+on_failure_sns_notifier = config.on_failure_sns_notifier()
+
+checks = [check for storage_sink in config.sinks() for check in storage_sink.checks()]
+
+if checks:
+
+    @dag(
+        dag_id="ami_data_quality_checks_dag",
+        schedule="0 4 * * *",
+        catchup=False,
+        start_date=datetime(2024, 1, 1),
+        tags=["ami"],
+        on_failure_callback=on_failure_sns_notifier,
+    )
+    def ami_data_quality_checks_dag():
+
+        @task()
+        def run_check(data_quality_check: BaseAMIDataQualityCheck):
+            check_passed = data_quality_check.check()
+            if not check_passed:
+                raise Exception(f"Check {data_quality_check.name()} did not pass")
+
+        for data_quality_check in checks:
+            run_check.override(task_id=f"{data_quality_check.name()}")(
+                data_quality_check
+            )
+
+    ami_data_quality_checks_dag()

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -19,6 +19,8 @@ sources:
 sinks:
 - type: snowflake
   id: my_snowflake_instance
+  checks:
+  - my-data-quality-check
 
 task_output:
   type: s3

--- a/test/amiadapters/storage/test_snowflake.py
+++ b/test/amiadapters/storage/test_snowflake.py
@@ -8,7 +8,9 @@ import pytz
 from amiadapters.adapters.beacon import BeaconRawSnowflakeLoader
 from amiadapters.models import DataclassJSONEncoder, GeneralMeter, GeneralMeterRead
 from amiadapters.outputs.base import ExtractOutput
-from amiadapters.storage.snowflake import SnowflakeStorageSink
+from amiadapters.storage.snowflake import (
+    SnowflakeStorageSink,
+)
 from test.base_test_case import BaseTestCase
 from test.amiadapters.test_beacon import beacon_meter_and_read_factory
 

--- a/test/amiadapters/test_config.py
+++ b/test/amiadapters/test_config.py
@@ -15,6 +15,7 @@ from amiadapters.config import (
 from amiadapters.adapters.metersense import MetersenseAdapter
 from amiadapters.adapters.sentryx import SentryxAdapter
 from amiadapters.adapters.subeca import SubecaAdapter
+from amiadapters.storage.snowflake import SnowflakeStorageSink
 from test.base_test_case import BaseTestCase
 
 
@@ -204,6 +205,15 @@ class TestConfig(BaseTestCase):
         notifier = config.on_failure_sns_notifier()
         self.assertIsInstance(notifier, SnsNotifier)
         self.assertEqual("my-sns-arn", notifier.target_arn)
+
+    @patch("amiadapters.config.ConfiguredStorageSink.connection")
+    def test_can_create_list_of_data_quality_checks(self, mock_connection):
+        config = AMIAdapterConfiguration.from_yaml(
+            self.get_fixture_path("all-config.yaml"),
+            self.get_fixture_path("all-secrets.yaml"),
+        )
+        checks = config.sinks()[0].checks()
+        self.assertEqual(1, len(checks))
 
 
 class TestFindConfigAndSecrets(BaseTestCase):

--- a/test/fixtures/all-config.yaml
+++ b/test/fixtures/all-config.yaml
@@ -48,6 +48,9 @@ sources:
 sinks:
 - type: snowflake
   id: my_snowflake_instance
+  checks:
+  - snowflake-meters-unique-by-device-id
+  - my-other-data-quality-check
 
 task_output:
   type: s3


### PR DESCRIPTION
This adds a new DAG that runs nightly daily quality checks. The checks are defined in the code and configured per storage sink (check the example YAML in this PR).

This check already caught an issue in the Bakman data! Nice.

Next up, I'll add some more checks.

Side note: The `config.py` file is kind of cumbersome. It's doing a lot of work and has some hackery. Could use some love someday. But it does give us a flexible, configurable system.