### PR TITLE
Make data quality checks automatically discoverable

### DIFF
--- a/amiadapters/config.py
+++ b/amiadapters/config.py
@@ -420,15 +420,18 @@ class ConfiguredStorageSink:
         """
         Return names of configured data quality checks for this sink.
         """
-        from amiadapters.storage.snowflake import SnowflakeMetersUniqueByDeviceIdCheck
+        from amiadapters.storage.base import BaseAMIDataQualityCheck
 
+        conn = self.connection()
+        checks_by_name = BaseAMIDataQualityCheck.get_all_checks_by_name(conn)
         result = []
         for name in self.data_quality_check_names:
-            if (
-                name == "snowflake-meters-unique-by-device-id"
-                and self.type == ConfiguredStorageSinkType.SNOWFLAKE
-            ):
-                result.append(SnowflakeMetersUniqueByDeviceIdCheck(self.connection()))
+            if name in checks_by_name:
+                result.append(checks_by_name[name])
+            else:
+                raise ValueError(
+                    f"Unrecognized data quality check name: {name}. Choices are: {", ".join(checks_by_name.keys())}"
+                )
         return result
 
     def _type(self, type: str) -> str:

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -355,7 +355,7 @@ class SnowflakeReadingsUniqueByDeviceIdAndFlowtimeCheck(BaseAMIDataQualityCheck)
         connection,
         readings_table_name: str = "readings",
     ):
-        self.connection = connection
+        super().__init__(connection)
         self.readings_table_name = readings_table_name
 
     def name(self) -> str:
@@ -370,7 +370,7 @@ class SnowflakeReadingsUniqueByDeviceIdAndFlowtimeCheck(BaseAMIDataQualityCheck)
                     PARTITION BY org_id, device_id, flowtime
                     ORDER BY interval_value, register_value
                 ) AS row_num
-                FROM readings
+                FROM {self.readings_table_name}
             ) as deduped
             WHERE row_num > 1
             """

--- a/test/fixtures/all-config.yaml
+++ b/test/fixtures/all-config.yaml
@@ -50,7 +50,6 @@ sinks:
   id: my_snowflake_instance
   checks:
   - snowflake-meters-unique-by-device-id
-  - my-other-data-quality-check
 
 task_output:
   type: s3


### PR DESCRIPTION
Previously, registering a data quality check with the system required some manual code in `config.py`. This makes it so any check which is a subclass of the base data quality check is automatically discoverable and a person only needs to include the check's name on their config.