### PR TITLE
Log extract range on every extract

### DIFF
--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -64,6 +64,9 @@ class BaseAMIAdapter(ABC):
         """
         Public function for extract stage.
         """
+        logger.info(
+            f"Extracting data for range {extract_range_start} to {extract_range_end}"
+        )
         # Use adapter implementation to extract data
         extracted_output = self._extract(run_id, extract_range_start, extract_range_end)
         # Output to intermediate storage, e.g. S3 or local files


### PR DESCRIPTION
It's often useful to see the extract date range in the logs, but right now only some adapters log it. This moves that log line to the base class so it's always there.