### PR TITLE
Add data gaps report, including ability for data quality checks to not alert on failure

### DIFF
--- a/amiadapters/storage/base.py
+++ b/amiadapters/storage/base.py
@@ -40,6 +40,11 @@ class BaseAMIDataQualityCheck(ABC):
     all_checks = []
 
     def __init_subclass__(cls, **kwargs):
+        """
+        This hook is called when python parses any of this class's child classes.
+        We use it to keep track of all child classes so we can automatically instantiate
+        them from the configuration.
+        """
         super().__init_subclass__(**kwargs)
         BaseAMIDataQualityCheck.all_checks.append(cls)
 
@@ -62,6 +67,13 @@ class BaseAMIDataQualityCheck(ABC):
         """
         pass
 
+    @abstractmethod
+    def notify_on_failure(self) -> bool:
+        """
+        :return: True if we should notify users when this check fails, else False.
+        """
+        pass
+
     @classmethod
     def get_all_checks_by_name(cls, connection) -> dict:
         """
@@ -71,7 +83,7 @@ class BaseAMIDataQualityCheck(ABC):
         # This is a hack to make python import the data quality check subclass
         # definitions, which adds them to cls.all_checks. We do this so that
         # subclasses are automatically registered, but someday we might decide
-        # that's not be worth the hackery.
+        # that's not worth the hackery.
         from amiadapters.storage import snowflake
 
         result = {}

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -319,6 +319,9 @@ class SnowflakeMetersUniqueByDeviceIdCheck(BaseAMIDataQualityCheck):
     def name(self) -> str:
         return "snowflake-meters-unique-by-device-id"
 
+    def notify_on_failure(self) -> bool:
+        return True
+
     def check(self) -> bool:
         """
         Run the check.
@@ -360,6 +363,9 @@ class SnowflakeReadingsUniqueByDeviceIdAndFlowtimeCheck(BaseAMIDataQualityCheck)
 
     def name(self) -> str:
         return "snowflake-readings-unique-by-device-id-and-flowtime"
+
+    def notify_on_failure(self) -> bool:
+        return True
 
     def check(self) -> bool:
         sql = f"""


### PR DESCRIPTION
We'd like to identify gaps in the readings timeseries, but because such gaps aren't necessarily the result of a pipeline issue, we don't want to alert ourselves anytime a gap exists. I've updated the data quality check code with an indicator saying whether users should be alerted if the check fails. I've also added a new check that runs some Snowflake SQL to identify gaps for each org. It logs the gap so that we can take a look in Airflow whenever we want.