### PR TITLE
Set Subeca location_id

### DIFF
--- a/amiadapters/adapters/subeca.py
+++ b/amiadapters/adapters/subeca.py
@@ -306,8 +306,7 @@ class SubecaAdapter(BaseAMIAdapter):
                 logger.warning(f"Skipping account {account} with null device ID")
                 continue
             account_id = account.accountId
-            # TODO check
-            location_id = None
+            location_id = account.accountId
             meter_id = account.meterSerial
             # TODO check
             endpoint_id = account.registerSerial

--- a/test/amiadapters/test_subeca.py
+++ b/test/amiadapters/test_subeca.py
@@ -289,6 +289,8 @@ class TestSubecaAdapter(BaseTestCase):
 
         self.assertEqual(len(meters), 1)
         self.assertEqual(meters[0].device_id, "D1")
+        self.assertEqual(meters[0].account_id, "A1")
+        self.assertEqual(meters[0].location_id, "A1")
         self.assertEqual(len(reads), 1)  # Register read added
         self.assertEqual(reads[0].interval_value, 1)
         self.assertEqual(reads[0].register_value, 100)


### PR DESCRIPTION
We'd like to set the Subeca location_id to be the account's `accountId`. This will accompany a database backfill.