### PR TITLE
Remove SSH IP allowlist

### DIFF
--- a/amideploy/README.md
+++ b/amideploy/README.md
@@ -48,7 +48,6 @@ touch environments/<your workspace>/<your workspace>.tfvars
 aws_profile = "my-aws-profile-name-associated-with-local-credentials"
 aws_region = "us-west-2"
 airflow_db_password = "myairflowdbpwd"
-ssh_ip_allowlist = ["my.ip.address/32"]
 airflow_hostname = "my-ami-connect-domain.com"
 ami_connect_s3_bucket_name = "my-s3-bucket-name"
 ```

--- a/amideploy/infrastructure/main.tf
+++ b/amideploy/infrastructure/main.tf
@@ -223,11 +223,11 @@ resource "aws_security_group" "airflow_server_sg" {
   description = "Allow Airflow app server traffic"
 
   ingress {
-    description = "Allow SSH from allowed IPs only"
+    description = "Allow SSH from public internet"
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = var.ssh_ip_allowlist
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {

--- a/amideploy/infrastructure/variables.tf
+++ b/amideploy/infrastructure/variables.tf
@@ -20,11 +20,6 @@ variable "airflow_hostname" {
   type        = string
 }
 
-variable "ssh_ip_allowlist" {
-  description = "IP CIDR blocks that can SSH into our AWS resources. ex: [192.168.1.1/32]"
-  type        = list(string)
-}
-
 variable "ami_connect_s3_bucket_name" {
   description = "Name for S3 bucket used for intermediate task outputs. Must be a globally unique name, so include your org name, e.g. my-company-ami-connect-bucket."
   type        = string


### PR DESCRIPTION
Originally we'd only allowed SSH access to the Airflow servers from IPs in a manually maintained allowlist. This has been tedious for me as a developer, e.g. when I work from a cafe. It will only get more tedious as new developers join in. We agreed we can remove this security feature and rely on regular SSH key authz.