### PR TITLE
MNWD does not fail when no data for raw load

### DIFF
--- a/amiadapters/adapters/xylem_moulton_niguel.py
+++ b/amiadapters/adapters/xylem_moulton_niguel.py
@@ -688,6 +688,11 @@ class XylemMoultonNiguelRawSnowflakeLoader(RawSnowflakeLoader):
         unique_by: list of field names used with org_id to uniquely identify a row in the base table
         """
         text = extract_outputs.from_file(extract_output_filename)
+        if not text:
+            logger.info(
+                f"No data found for {extract_output_filename}, skipping raw load"
+            )
+            return
         raw_data = [raw_dataclass(**json.loads(d)) for d in text.strip().split("\n")]
         temp_table = f"temp_{table}"
         fields = [f.lower() for f in raw_dataclass.__dataclass_fields__.keys()]


### PR DESCRIPTION
Seeing failures in the pipeline during raw data loads because backfills are finding no `ami` readings, e.g. in the 2024-07-30 00:00:00 to 2024-08-01 00:00:00 date range. This will stop the bleeding, and I'll check the data source to confirm there aren't `ami` readings for that period.