### PR TITLE
Xylem MN adapter uses service address and service point to create concatenated location_id

### DIFF
--- a/amiadapters/adapters/xylem_moulton_niguel.py
+++ b/amiadapters/adapters/xylem_moulton_niguel.py
@@ -284,7 +284,11 @@ class XylemMoultonNiguelAdapter(BaseAMIAdapter):
                 # Take the first, which is most recently active
                 account_id = customers[0].account_id
 
-            location_id = service_point.service_address if service_point else None
+            location_id = None
+            if service_point is not None:
+                location_id = self._create_location_id(
+                    service_point.service_address, service_point.service_point
+                )
 
             meter = GeneralMeter(
                 org_id=self.org_id,
@@ -424,7 +428,12 @@ class XylemMoultonNiguelAdapter(BaseAMIAdapter):
             ):
                 matching_meter = meter
                 break
-        location_id = matching_meter.service_address if matching_meter else None
+
+        location_id = None
+        if matching_meter is not None:
+            location_id = self._create_location_id(
+                matching_meter.service_address, matching_meter.service_point
+            )
 
         account_id = None
         if matching_meter:
@@ -436,6 +445,9 @@ class XylemMoultonNiguelAdapter(BaseAMIAdapter):
                     account_id = customer.account_id
                     break
         return location_id, account_id
+
+    def _create_location_id(self, service_address: str, service_point: str) -> str:
+        return f"{service_address}-{service_point}"
 
     def _parse_flowtime(self, raw_flowtime: str) -> datetime:
         if "T" in raw_flowtime:

--- a/test/amiadapters/test_xylem_moulton_niguel.py
+++ b/test/amiadapters/test_xylem_moulton_niguel.py
@@ -203,7 +203,7 @@ class TestMetersenseAdapter(BaseTestCase):
                 org_id="this-org",
                 device_id="M1",
                 account_id="67890",
-                location_id="100",
+                location_id="100-1",
                 meter_id="M1",
                 endpoint_id="ERT1",
                 meter_install_date=datetime.datetime(
@@ -227,7 +227,7 @@ class TestMetersenseAdapter(BaseTestCase):
                 org_id="this-org",
                 device_id="M1",
                 account_id="67890",
-                location_id="100",
+                location_id="100-1",
                 flowtime=datetime.datetime(
                     2023,
                     1,
@@ -287,8 +287,8 @@ class TestMetersenseAdapter(BaseTestCase):
         meters, reads = self.adapter._transform("run1", extract_outputs)
         self.assertEqual(len(meters), 1)
         self.assertEqual(len(reads), 2)
-        self.assertEqual("current-address", reads[0].location_id)
-        self.assertEqual("current-address", reads[1].location_id)
+        self.assertEqual("current-address-1", reads[0].location_id)
+        self.assertEqual("current-address-1", reads[1].location_id)
         self.assertEqual("current-account", reads[0].account_id)
         self.assertEqual("current-account", reads[1].account_id)
 


### PR DESCRIPTION
Per conversation with @jaime-82, we'd like the `location_id` for Xylem MNWD to be a combo of the service address and service point. This is the code change. I'm going to try and update the Snowflake data with SQL before deploying this.