### PR TITLE
Allow adapters to specify the number of days in their nightly runs; bump Metersense to 3 days

### DIFF
--- a/amiadapters/adapters/metersense.py
+++ b/amiadapters/adapters/metersense.py
@@ -247,6 +247,13 @@ class MetersenseAdapter(BaseAMIAdapter):
     def name(self) -> str:
         return f"metersense-{self.org_id}"
 
+    def default_extract_interval_days(self):
+        """
+        We've seen in some cases that Metersense meter reads aren't fully represented in the source until two days
+        after the flowtime. We set our standard extract range to 3+ days to cover this lag.
+        """
+        return 3
+
     def _extract(
         self,
         run_id: str,

--- a/test/amiadapters/test_base.py
+++ b/test/amiadapters/test_base.py
@@ -125,7 +125,9 @@ class TestExtractRangeCalculator(BaseTestCase):
         self.snowflake_sink = MagicMock(spec=SnowflakeStorageSink)
         self.snowflake_sink.calculate_end_of_backfill_range.return_value = 3
         sinks = [self.snowflake_sink]
-        self.calculator = ExtractRangeCalculator(org_id="my_org", storage_sinks=sinks)
+        self.calculator = ExtractRangeCalculator(
+            org_id="my_org", storage_sinks=sinks, default_interval_days=2
+        )
 
     @patch("amiadapters.adapters.base.datetime")
     def test_calculate_extract_range__both_dates_none(self, mock_datetime):

--- a/test/amiadapters/test_metersense.py
+++ b/test/amiadapters/test_metersense.py
@@ -256,6 +256,7 @@ class TestMetersenseAdapter(BaseTestCase):
         self.assertEqual("db-name", self.adapter.database_db_name)
         self.assertEqual("dbu", self.adapter.database_user)
         self.assertEqual("dbp", self.adapter.database_password)
+        self.assertEqual(3, self.adapter.default_extract_interval_days())
 
     def test_transform(self):
         meter = self._meter_factory()


### PR DESCRIPTION
Per a data issue we found, we'd like to let Metersense go back for the last 3 days of data each night. Previously, this was hardcoded to 2 days for all adapters. This update allows adapters to specify how many days they should go back in a  nightly run, then bumps Metersense to 3.

Someday we might want to let folks configure this per utility, which would be easy to do. I left that for later.