### PR TITLE
Fix misuse of logging library; Add note about Aclara SFTP

### DIFF
--- a/amiadapters/adapters/aclara.py
+++ b/amiadapters/adapters/aclara.py
@@ -16,6 +16,7 @@ from amiadapters.models import DataclassJSONEncoder, GeneralMeter, GeneralMeterR
 from amiadapters.outputs.base import ExtractOutput
 from amiadapters.storage.snowflake import RawSnowflakeLoader
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -89,7 +90,7 @@ class AclaraAdapter(BaseAMIAdapter):
         extract_range_start: datetime,
         extract_range_end: datetime,
     ):
-        logging.info(
+        logger.info(
             f"Connecting to Aclara SFTP for data between {extract_range_start} and {extract_range_end}"
         )
         downloaded_files = []
@@ -137,7 +138,7 @@ class AclaraAdapter(BaseAMIAdapter):
         for file in files_to_download:
             local_csv = f"{self.local_download_directory}/{file}"
             downloaded_files.append(local_csv)
-            logging.info(
+            logger.info(
                 f"Downloading {file} from FTP at {self.sftp_host} to {local_csv}"
             )
             sftp.get(self.sftp_meter_and_reads_folder + "/" + file, local_csv)

--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -256,7 +256,7 @@ class BaseAMIAdapter(ABC):
         }
         result = mapping.get(size)
         if size is not None and result is None:
-            logging.info(f"Unable to map meter size: {size}")
+            logger.info(f"Unable to map meter size: {size}")
         return result
 
     def map_reading(

--- a/amiadapters/adapters/metersense.py
+++ b/amiadapters/adapters/metersense.py
@@ -267,7 +267,7 @@ class MetersenseAdapter(BaseAMIAdapter):
             remote_host=self.database_host,
             remote_port=self.database_port,
         ) as ctx:
-            logging.info("Created SSH tunnel")
+            logger.info("Created SSH tunnel")
             connection = oracledb.connect(
                 user=self.database_user,
                 password=self.database_password,

--- a/amiadapters/adapters/subeca.py
+++ b/amiadapters/adapters/subeca.py
@@ -92,7 +92,7 @@ class SubecaAdapter(BaseAMIAdapter):
         extract_range_start: datetime,
         extract_range_end: datetime,
     ) -> ExtractOutput:
-        logging.info(
+        logger.info(
             f"Retrieving Subeca data between {extract_range_start} and {extract_range_end}"
         )
         account_ids = self._extract_all_account_ids()

--- a/amiadapters/adapters/xylem_moulton_niguel.py
+++ b/amiadapters/adapters/xylem_moulton_niguel.py
@@ -179,7 +179,7 @@ class XylemMoultonNiguelAdapter(BaseAMIAdapter):
             remote_host=self.database_host,
             remote_port=self.database_port,
         ) as ctx:
-            logging.info("Created SSH tunnel")
+            logger.info("Created SSH tunnel")
             connection = psycopg2.connect(
                 user=self.database_user,
                 password=self.database_password,

--- a/docs/adapters/aclara.md
+++ b/docs/adapters/aclara.md
@@ -20,6 +20,11 @@ sources:
   sftp_local_known_hosts_file: ./known-hosts
 ```
 
+The `./known-hosts` file is a special SSH known hosts file that should contain info about the Aclara server at `sftp_host`.
+If your SFTP connection opens but then shuts immediately, you may have an issue with known hosts. We've worked around it in
+the past by running `ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())` in the pipeline code one time, but you don't want to
+run with this option in production as it posts security risks.
+
 Secrets:
 ```yaml
 sources:


### PR DESCRIPTION
Resizing the CaDC EC2 created some issue with the known hosts configuration for the Aclara SFTP. I was able to get it fixed on the server by temporarily running the pipeline with this code included: `ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())`. That presumably added an entry in a known hosts file somewhere, but none of the known hosts files I know about were modified. It worked, so I'm moving on 🤷 I dropped a note in the docs here.

Also fixing `logging.info` -> `logger.info` typos.