### PR TITLE
Remove debugger breakpoint and add unit tests

### DIFF
--- a/amiadapters/adapters/metersense.py
+++ b/amiadapters/adapters/metersense.py
@@ -279,9 +279,7 @@ class MetersenseAdapter(BaseAMIAdapter):
             cursor = connection.cursor()
 
             files = self._query_tables(cursor, extract_range_start, extract_range_end)
-        import pdb
 
-        pdb.set_trace()
         return ExtractOutput(files)
 
     def _query_tables(


### PR DESCRIPTION
I made a snafu last week and left a breakpoint in the Metersense adapter code. It got merged and deployed, so all Metersense jobs since last week got stuck at the breakpoint and failed. This removes the breakpoint and adds a unit test to make sure the Metersense extract function's happy path works (not sure why I skipped that the first time around!).