### PR TITLE
Use database and timestamp to help concurrent LB backfills

### DIFF
--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -279,15 +279,23 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
         conn = self.sink_config.connection()
 
         # Temporary hack for Long Beach backfill, remove after finished
-        if org_id == 'cadc_long_beach':
-            earliest = conn.cursor().execute("select earliest from backfills where org_id = 'cadc_long_beach'").fetchall()[0][0]
+        if org_id == "cadc_long_beach":
+            earliest = (
+                conn.cursor()
+                .execute(
+                    "select earliest from backfills where org_id = 'cadc_long_beach'"
+                )
+                .fetchall()[0][0]
+            )
             logger.info(f"Earliest end date of backfill for {org_id} is {earliest}")
             from datetime import timedelta
+
             next_end = earliest - timedelta(days=3)
-            conn.cursor().execute(f"update backfills set earliest = '{next_end}' where org_id = 'cadc_long_beach'").fetchall()[0][0]
+            conn.cursor().execute(
+                f"update backfills set earliest = '{next_end}' where org_id = 'cadc_long_beach'"
+            ).fetchall()[0][0]
             logger.info(f"Set earliest to {next_end.isoformat()}")
             return earliest
-
 
         # Calculate nth percentile of number of readings per day
         # We will use that as a threshold for what we consider "already backfilled"


### PR DESCRIPTION
Long Beach backfills for 3+ days of data take 4-8 hours to run. I'd like to kick off concurrent backfills, but our automated backfill system doesn't work well in this scenario. It tries to pick a backfill range by finding the earliest date in the `readings` table we've already backfilled. But if the previous backfill hasn't written its data yet, the next job runs on the same range as the previous job.

This is a hack to use a timestamp in the database, updated when each backfill job kicks off, to make concurrent backfills pick the right range for a backfill. I intend to remove it after LB backfills are finished. We probably do want to use database state to determine things like backfill range someday, but I'd rather put more thought into than this.