### PR TITLE
Cut over to database-driven configuration

### DIFF
--- a/amiadapters/configuration/base.py
+++ b/amiadapters/configuration/base.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 
 import snowflake.connector
@@ -80,6 +81,21 @@ def update_backfill_configuration(
         )
         connection = create_snowflake_from_secrets_file(secrets_file)
         database.update_backfill_configuration(connection, new_backfill_configuration)
+
+
+def remove_backfill_configuration(
+    config_file: str,
+    secrets_file: str,
+    org_id: str,
+    start_date: datetime,
+    end_date: datetime,
+):
+    if _use_database_for_config(config_file, secrets_file):
+        logger.info(
+            f"Removing backfill configuration in database for {org_id} {start_date} {end_date}"
+        )
+        connection = create_snowflake_from_secrets_file(secrets_file)
+        database.remove_backfill_configuration(connection, org_id, start_date, end_date)
 
 
 def update_notification_configuration(

--- a/amiadapters/configuration/database.py
+++ b/amiadapters/configuration/database.py
@@ -73,7 +73,7 @@ def get_configuration(snowflake_connection) -> Tuple[
                     "ssh_tunnel_key_path"
                 )
                 source["database_host"] = type_specific_config.get("database_host")
-                source["database_port"] = type_specific_config.get("database_port")
+                source["database_port"] = int(type_specific_config.get("database_port"))
             case "neptune":
                 source["external_adapter_location"] = type_specific_config.get(
                     "external_adapter_location"

--- a/amicontrol/dags/ami_data_quality_checks_dag.py
+++ b/amicontrol/dags/ami_data_quality_checks_dag.py
@@ -5,7 +5,6 @@ from airflow.decorators import dag, task
 
 from amiadapters.config import (
     AMIAdapterConfiguration,
-    find_config_yaml,
     find_secrets_yaml,
 )
 
@@ -13,7 +12,7 @@ from amiadapters.storage.base import BaseAMIDataQualityCheck
 
 logger = logging.getLogger(__name__)
 
-config = AMIAdapterConfiguration.from_yaml(find_config_yaml(), find_secrets_yaml())
+config = AMIAdapterConfiguration.from_database(find_secrets_yaml())
 on_failure_sns_notifier = config.on_failure_sns_notifier()
 
 checks = [check for storage_sink in config.sinks() for check in storage_sink.checks()]

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -6,7 +6,6 @@ from airflow.models.param import Param
 from amiadapters.adapters.base import BaseAMIAdapter
 from amiadapters.config import (
     AMIAdapterConfiguration,
-    find_config_yaml,
     find_secrets_yaml,
 )
 
@@ -90,7 +89,7 @@ def ami_control_dag_factory(
 #######################################################
 # Configure DAGs
 #######################################################
-config = AMIAdapterConfiguration.from_yaml(find_config_yaml(), find_secrets_yaml())
+config = AMIAdapterConfiguration.from_database(find_secrets_yaml())
 utility_adapters = config.adapters()
 backfills = config.backfills()
 on_failure_sns_notifier = config.on_failure_sns_notifier()

--- a/cli.py
+++ b/cli.py
@@ -22,6 +22,7 @@ from amiadapters.config import (
 from amiadapters.configuration.base import (
     add_source_configuration,
     get_configuration,
+    remove_backfill_configuration,
     remove_sink_configuration,
     remove_source_configuration,
     update_backfill_configuration,
@@ -237,6 +238,12 @@ def add_source(
             help='Subeca API URL for this org, e.g. "https://my-utility.api.subeca.online". Applicable to types: [subeca]'
         ),
     ] = None,
+    external_adapter_location: Annotated[
+        str,
+        typer.Option(
+            help="Path on Airflow server to Neptune adapter module. Applicable to types: [neptune]"
+        ),
+    ] = None,
     sinks: Annotated[
         List[str],
         typer.Option(
@@ -266,6 +273,7 @@ def add_source(
         "database_host": database_host,
         "database_port": database_port,
         "api_url": api_url,
+        "external_adapter_location": external_adapter_location,
         "sinks": sinks or [],
     }
     add_source_configuration(None, secrets_file, new_sink_configuration)
@@ -333,6 +341,12 @@ def update_source(
             help='Subeca API URL for this org, e.g. "https://my-utility.api.subeca.online". Applicable to types: [subeca]'
         ),
     ] = None,
+    external_adapter_location: Annotated[
+        str,
+        typer.Option(
+            help="Path on Airflow server to Neptune adapter module. Applicable to types: [neptune]"
+        ),
+    ] = None,
     sinks: Annotated[
         List[str],
         typer.Option(
@@ -380,6 +394,8 @@ def update_source(
         new_sink_configuration["database_port"] = database_port
     if api_url is not None:
         new_sink_configuration["api_url"] = api_url
+    if external_adapter_location is not None:
+        new_sink_configuration["external_adapter_location"] = external_adapter_location
     if sinks is not None:
         new_sink_configuration["sinks"] = sinks
     update_source_configuration(None, secrets_file, new_sink_configuration)
@@ -510,6 +526,36 @@ def update_backfill(
         "schedule": schedule,
     }
     update_backfill_configuration(None, secrets_file, new_backfill_configuration)
+
+
+@config_app.command()
+def remove_backfill(
+    org_id: Annotated[
+        str,
+        typer.Argument(
+            help="Often source's organization name and is used as unique identifier."
+        ),
+    ],
+    start_date: Annotated[
+        datetime,
+        typer.Argument(
+            help="Earliest date in range to be backfilled in YYYY-MM-DD format."
+        ),
+    ],
+    end_date: Annotated[
+        datetime,
+        typer.Argument(
+            help="Latest date in range to be backfilled in YYYY-MM-DD format."
+        ),
+    ],
+    secrets_file: Annotated[
+        str, typer.Option(help="Path to local secrets file.")
+    ] = DEFAULT_SECRETS_PATH,
+):
+    """
+    Removes backfill configuration in database. Matches on org_id+start_date+end_date.
+    """
+    remove_backfill_configuration(None, secrets_file, org_id, start_date, end_date)
 
 
 @config_app.command()

--- a/test/amiadapters/configuration/test_database.py
+++ b/test/amiadapters/configuration/test_database.py
@@ -41,7 +41,12 @@ class TestDatabase(BaseTestCase):
                     "type": "sentryx",
                     "org_id": "my_sentryx_utility",
                     "timezone": "America/Los_Angeles",
-                    "config": json.dumps({"use_raw_data_cache": False}),
+                    "config": json.dumps(
+                        {
+                            "use_raw_data_cache": False,
+                            "utility_name": "my-sentryx-utility",
+                        }
+                    ),
                 },
                 {
                     "id": 3,
@@ -169,7 +174,7 @@ class TestDatabase(BaseTestCase):
 
         # Ensure TRUNCATE then INSERT are executed
         expected_calls = [
-            call.execute("TRUNCATE TABLE configuration_task_outputs"),
+            call.execute("DELETE FROM configuration_task_outputs"),
             call.execute(
                 """
         INSERT INTO configuration_task_outputs (type, s3_bucket, local_output_path)
@@ -192,7 +197,7 @@ class TestDatabase(BaseTestCase):
         update_task_output_configuration(self.mock_connection, config)
 
         self.mock_cursor.execute.assert_any_call(
-            "TRUNCATE TABLE configuration_task_outputs"
+            "DELETE FROM configuration_task_outputs"
         )
         self.mock_cursor.execute.assert_any_call(
             """

--- a/test/fixtures/all-config.yaml
+++ b/test/fixtures/all-config.yaml
@@ -9,6 +9,7 @@ sources:
 - type: sentryx
   org_id: my_sentryx_utility
   timezone: America/Los_Angeles
+  utility_name: "my-sentryx-utility"
   use_raw_data_cache: False
   sinks:
   - my_snowflake_instance

--- a/test/integration/snowflake_integration_test.py
+++ b/test/integration/snowflake_integration_test.py
@@ -27,7 +27,7 @@ class BaseSnowflakeIntegrationTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.config = AMIAdapterConfiguration.from_yaml("config.yaml", "secrets.yaml")
+        cls.config = AMIAdapterConfiguration.from_database("secrets.yaml")
         # Hack! Pick an adapter out of the config so we can create a connection to Snowflake.
         adapter = cls.config.adapters()[0]
         cls.snowflake_sink = adapter.storage_sinks[0]


### PR DESCRIPTION
This finishes a couple of CLI commands that I used to configure CaDC and Current in their new config databases. It also cuts the production DAGs over to database-driven config. I've deployed this and tested already.