### PR TITLE
Make Xylem MN adapter go back 6 days for standard daily run

### DIFF
--- a/amiadapters/adapters/xylem_moulton_niguel.py
+++ b/amiadapters/adapters/xylem_moulton_niguel.py
@@ -165,6 +165,13 @@ class XylemMoultonNiguelAdapter(BaseAMIAdapter):
     def name(self) -> str:
         return f"xylem-moulton-niguel-{self.org_id}"
 
+    def default_extract_interval_days(self):
+        """
+        We've seen in some cases that Moulton's meter reads aren't fully represented in the source until two days
+        after the flowtime. We set our standard extract range to 3+ days to cover this lag.
+        """
+        return 6
+
     def _extract(
         self,
         run_id: str,


### PR DESCRIPTION
I noticed that we aren't getting the full number of reads for MNWD's daily run. This bumps the number of days back to try and fix that. I'll check next week to see if it looks better - some testing today makes me feel that it'll work.