### PR TITLE
Sentryx throws error when it receives non-200; DAG does not run post-process for Current

### DIFF
--- a/amiadapters/adapters/sentryx.py
+++ b/amiadapters/adapters/sentryx.py
@@ -216,10 +216,9 @@ class SentryxAdapter(BaseAMIAdapter):
             )
             response = requests.get(url, headers=headers, params=params)
             if not response.status_code == 200:
-                logger.warning(
-                    f"Non-200 response from devices endpoint: {response.status_code}"
+                raise Exception(
+                    f"Non-200 response from devices endpoint: {response.status_code} {response.text}"
                 )
-                return []
             data = response.json()
             raw_meters = data.get("meters", [])
             num_meters += len(raw_meters)
@@ -272,10 +271,9 @@ class SentryxAdapter(BaseAMIAdapter):
             )
             response = requests.get(url, headers=headers, params=params)
             if not response.status_code == 200:
-                logger.warning(
-                    f"Non-200 response from device consumption endpoint: {response.status_code}"
+                raise Exception(
+                    f"Non-200 response from device consumption endpoint: {response.status_code} {response.text}"
                 )
-                return []
             data = response.json()
             raw_meters = data.get("meters", [])
             num_meters += len(raw_meters)

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -626,7 +626,7 @@ class SnowflakeReadingsHaveNoDataGapsCheck(BaseAMIDataQualityCheck):
                 SELECT
                     org_id,
                     MIN(TO_DATE (flowtime)) AS min_day,
-                    MAX(TO_DATE (flowtime)) AS max_day
+                    MAX(TO_DATE (flowtime)) - INTERVAL '2 DAY' AS max_day
                 FROM
                     {self.readings_table_name}
                 GROUP BY

--- a/amicontrol/dags/ami_meter_read_dag.py
+++ b/amicontrol/dags/ami_meter_read_dag.py
@@ -76,6 +76,9 @@ def ami_control_dag_factory(
         @task()
         def post_process(**context):
             run_id = context["dag_run"].run_id
+            # TODO make this a configuration option, but for, while Current post processing is broken, skip it.
+            if "current" in adapter.org_id:
+                return
             adapter.post_process(run_id)
 
         # Set sequence of tasks for this utility

--- a/test/amiadapters/test_sentryx.py
+++ b/test/amiadapters/test_sentryx.py
@@ -202,8 +202,8 @@ class TestSentryxAdapter(BaseTestCase):
         side_effect=[mocked_get_devices_response_first_page(), mocked_response_500()],
     )
     def test_extract_all_meters__non_200_status_code(self, mock_get):
-        result = self.adapter._extract_all_meters()
-        self.assertEqual(0, len(result))
+        with self.assertRaises(Exception):
+            self.adapter._extract_all_meters()
 
     @mock.patch(
         "requests.get",
@@ -268,10 +268,10 @@ class TestSentryxAdapter(BaseTestCase):
         ],
     )
     def test_extract_consumption_for_all_meters__non_200_response(self, mock_get):
-        result = self.adapter._extract_consumption_for_all_meters(
-            self.range_start, self.range_end
-        )
-        self.assertEqual(0, len(result))
+        with self.assertRaises(Exception):
+            self.adapter._extract_consumption_for_all_meters(
+                self.range_start, self.range_end
+            )
 
     def test_transform_meters_and_reads(self):
         meters = [


### PR DESCRIPTION
A couple changes:
- I discovered that the Sentryx adapter doesn't throw an error if it receives a non-200 response from the API. This PR makes it throw an error and report the HTTP response's message
- We're still working on some Snowflake permissions issues with Current's leak detection query, so I'm hardcoding the DAG to not run those queries for Current's pipeline. Ideally this would be a config option, but I wanted to be quick and dirty for now.