### PR TITLE
Deploy AMI Connect from Current fork

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mdowell12 @christophertull @dmarulli @jin-current @pat-current
+* @mdowell12 @jin-current @pat-current

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# ami-connect
+# Private fork of ami-connect
 
-Seamless pipelines for AMI water data, now as easy to access as turning on a tap.
+Current Software fork of open source [AMI Connect](github.com/California-Data-Collaborative/ami-connect) with
+code that makes the pipeline fit Current's environment. Where possible, we try to merge changes to the upstream
+open source repo.
 
 ## AMI Adapters
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,7 +23,7 @@ else
     FULL_RESTART="false"
 fi
 
-AMI_CONNECT_REPO="California-Data-Collaborative/ami-connect.git"
+AMI_CONNECT_REPO="currentsoftwareapp/current-software-ami-connect"
 # If you include a private neptune adapter in your deploy,
 # set the AMI_CONNECT_NEPTUNE_REPO_URL environment variable before running this script
 # Defaults to empty string if not set.


### PR DESCRIPTION
Updates the deploy script to deploy AMI Connect from Current's fork. Also adds a note to README and updates CODEOWNERS.