### PR TITLE
Update adapter docs to reflect latest cli

### DIFF
--- a/docs/adapters/aclara.md
+++ b/docs/adapters/aclara.md
@@ -11,7 +11,7 @@ The Aclara adapter uses SFTP to retrieve meter read data from an Aclara server.
 
 Example:
 ```
-python cli.py config add-source my_utility aclara America/Los_Angeles --sftp-host my-sftp-host --sftp-remote-data-directory ./data --sftp-local-download-directory ./output --sftp-local-known-hosts-file ./known-hosts --sinks my_snowflake
+python cli.py config add-source my_utility aclara America/Los_Angeles --config sftp-host=my-sftp-host --config sftp-remote-data-directory=./data --config sftp-local-download-directory=./output --config sftp-local-known-hosts-file=./known-hosts --sinks my_snowflake
 ```
 
 The `./known-hosts` file is a special SSH known hosts file that should contain info about the Aclara server at `sftp_host`. Its contents
@@ -21,7 +21,7 @@ are read into the database as the "sftp_known_hosts_str" value.
 
 Example:
 ```
-python cli.py config update-secret my_utility --source-type aclara --sftp-user my_user --sftp-password my_password
+python cli.py config update-secret my_utility --source-type aclara --secret sftp-user=my_user --secret sftp-password=my_password
 ```
 
 ## Limitations

--- a/docs/adapters/beacon.md
+++ b/docs/adapters/beacon.md
@@ -15,7 +15,7 @@ python cli.py config add-source my_utility beacon_360 America/Los_Angeles --sink
 
 Example:
 ```
-python cli.py config update-secret my_utility --source-type beacon_360 --user my_user --password my_password
+python cli.py config update-secret my_utility --source-type beacon_360 --secret user=my_user --secret password=my_password
 ```
 
 ## Limitations

--- a/docs/adapters/metersense.md
+++ b/docs/adapters/metersense.md
@@ -15,7 +15,7 @@ Some setup outside of AMI Connect may include:
 
 Example:
 ```
-python cli.py config add-source my_utility metersense America/Los_Angeles --ssh-tunnel-server-host my-tunnel-host --ssh-tunnel-key-path ./key --database-host my-db-host --database-port 1521 --sinks my_snowflake
+python cli.py config add-source my_utility metersense America/Los_Angeles --config ssh-tunnel-server-host=my-tunnel-host --config ssh-tunnel-key-path=./key --config database-host=my-db-host --config database-port=1521 --sinks my_snowflake
 ```
 
 ## Secrets
@@ -27,7 +27,7 @@ python cli.py config add-source my_utility metersense America/Los_Angeles --ssh-
 
 Example:
 ```
-python cli.py config update-secret my_utility --source-type metersense --ssh-tunnel-username my_user --database-db-name my_database --database-user my_db_user --database-password my_db_password
+python cli.py config update-secret my_utility --source-type metersense --secret ssh-tunnel-username=my_user --secret database-db-name=my_database --secret database-user=my_db_user --secret database-password=my_db_password
 ```
 
 ## Limitations

--- a/docs/adapters/neptune.md
+++ b/docs/adapters/neptune.md
@@ -19,14 +19,14 @@ server and add it as a [deploy key](https://docs.github.com/en/authentication/co
 
 Example:
 ```
-python cli.py config add-source my_utility neptune America/Los_Angeles --external-adapter-location ./neptune-ami-connect/neptune --sinks my_snowflake
+python cli.py config add-source my_utility neptune America/Los_Angeles --config external-adapter-location=./neptune-ami-connect/neptune --sinks my_snowflake
 ```
 
 ## Secrets
 
 Example:
 ```
-python cli.py config update-secret my_utility --source-type neptune --api-key my_api_key --site-id 1234 --client-id api-client_my_client --client_secret my_secret
+python cli.py config update-secret my_utility --source-type neptune --secret api-key=my_api_key --secret site-id=1234 --secret client-id=api-client_my_client --secret client_secret=my_secret
 ```
 
 ## Notes

--- a/docs/adapters/sentryx.md
+++ b/docs/adapters/sentryx.md
@@ -8,14 +8,14 @@ The Sentryx adapter retrieves data via Sentryx's HTTP API.
 
 Example:
 ```
-python cli.py config add-source my_utility sentryx America/Los_Angeles --utility-name name-of-my-utility-in-api-url ./neptune-ami-connect --sinks my_snowflake
+python cli.py config add-source my_utility sentryx America/Los_Angeles --config utility-name=name-of-my-utility-in-api-url --sinks my_snowflake
 ```
 
 ## Secrets
 
 Example:
 ```
-python cli.py config update-secret my_utility --source-type sentryx --api-key my_api_key
+python cli.py config update-secret my_utility --source-type sentryx --secret api-key=my_api_key
 ```
 
 ## Limitations

--- a/docs/adapters/subeca.md
+++ b/docs/adapters/subeca.md
@@ -8,14 +8,14 @@ The Subeca adapter retrieves data via Subeca's HTTP API.
 
 Example:
 ```
-python cli.py config add-source my_utility subeca America/Los_Angeles --api-url https://my-source-name.api.subeca.online --sinks my_snowflake
+python cli.py config add-source my_utility subeca America/Los_Angeles --config api-url=https://my-source-name.api.subeca.online --sinks my_snowflake
 ```
 
 ## Secrets
 
 Example:
 ```
-python cli.py config update-secret my_utility --source-type subeca --api-key my_api_key
+python cli.py config update-secret my_utility --source-type subeca --secret api-key=my_api_key
 ```
 
 ## Limitations

--- a/docs/adapters/xylem_moulton_niguel.md
+++ b/docs/adapters/xylem_moulton_niguel.md
@@ -13,7 +13,7 @@ This adapter was built specially for MNWD and is not compatible for other utilit
 
 Example:
 ```
-python cli.py config add-source my_utility xylem_moulton_niguel America/Los_Angeles --ssh-tunnel-server-host my-tunnel-host --ssh-tunnel-key-path ./key --database-host my-db-host --database-port 1521 --sinks my_snowflake
+python cli.py config add-source my_utility xylem_moulton_niguel America/Los_Angeles --config ssh-tunnel-server-host=my-tunnel-host --config ssh-tunnel-key-path=./key --config database-host=my-db-host --config database-port=1521 --sinks my_snowflake
 ```
 
 ## Secrets
@@ -25,7 +25,7 @@ python cli.py config add-source my_utility xylem_moulton_niguel America/Los_Ange
 
 Example:
 ```
-python cli.py config update-secret my_utility --source-type xylem_moulton_niguel --ssh-tunnel-username my_user --database-db-name my_database --database-user my_db_user --database-password my_db_password
+python cli.py config update-secret my_utility --source-type xylem_moulton_niguel --secret ssh-tunnel-username=my_user --secret database-db-name=my_database --secret database-user=my_db_user --secret database-password=my_db_password
 ```
 
 ## Limitations


### PR DESCRIPTION
Updates adapter docs to use `--config` and `--secret` syntax when adding/updating source config and secrets.