### PR TITLE
Add Xylem Data Lake adapter

### DIFF
--- a/amiadapters/adapters/xylem_datalake.py
+++ b/amiadapters/adapters/xylem_datalake.py
@@ -103,19 +103,19 @@ def _create_superset_session(
 ) -> requests.Session:
     """Keycloak PKCE OAuth -> Xylem Data Lake -> Superset session."""
     session = requests.Session()
-    session.headers.update({
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/145.0.0.0 Safari/537.36"
-        ),
-    })
+    session.headers.update(
+        {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/145.0.0.0 Safari/537.36"
+            ),
+        }
+    )
 
     code_verifier = secrets.token_urlsafe(32)
     code_challenge = (
-        base64.urlsafe_b64encode(
-            hashlib.sha256(code_verifier.encode()).digest()
-        )
+        base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
         .rstrip(b"=")
         .decode()
     )
@@ -205,7 +205,9 @@ def _refresh_csrf(session: requests.Session, superset_url: str) -> None:
         f"{superset_url}/api/v1/security/csrf_token/",
         allow_redirects=False,
     )
-    if csrf_resp.status_code == 200 and "application/json" in csrf_resp.headers.get("Content-Type", ""):
+    if csrf_resp.status_code == 200 and "application/json" in csrf_resp.headers.get(
+        "Content-Type", ""
+    ):
         session.headers["X-CSRFToken"] = csrf_resp.json()["result"]
         session.headers["Referer"] = f"{superset_url}/sqllab/"
         logger.info("CSRF token refreshed")
@@ -342,7 +344,9 @@ class XylemDatalakeAdapter(BaseAMIAdapter):
         all_rows = []
         current_end = range_end
         while current_end > range_start:
-            current_start = max(current_end - timedelta(hours=self.chunk_hours), range_start)
+            current_start = max(
+                current_end - timedelta(hours=self.chunk_hours), range_start
+            )
             sql = (
                 f"SELECT {columns} FROM {table} "
                 f"WHERE {date_column} >= '{current_start:%Y-%m-%d %H:%M:%S}' "
@@ -367,24 +371,36 @@ class XylemDatalakeAdapter(BaseAMIAdapter):
             try:
                 resp = self._session.post(
                     f"{self.superset_url}/api/v1/sqllab/execute/",
-                    json={"database_id": self.database_id, "sql": sql, "runAsync": False},
+                    json={
+                        "database_id": self.database_id,
+                        "sql": sql,
+                        "runAsync": False,
+                    },
                     allow_redirects=False,
                 )
             except requests.exceptions.TooManyRedirects:
                 auth_failures += 1
                 logger.warning("Redirect loop (session expired)")
                 if auth_failures > MAX_AUTH_ATTEMPTS:
-                    raise RuntimeError(f"Max re-auth attempts ({MAX_AUTH_ATTEMPTS}) reached")
+                    raise RuntimeError(
+                        f"Max re-auth attempts ({MAX_AUTH_ATTEMPTS}) reached"
+                    )
                 self._session = self._reauth(auth_failures - 1)
                 self._requests_since_csrf = 0
                 continue
 
             if _session_expired(resp):
                 auth_failures += 1
-                reason = f"HTTP {resp.status_code}" if resp.status_code != 200 else "non-JSON response"
+                reason = (
+                    f"HTTP {resp.status_code}"
+                    if resp.status_code != 200
+                    else "non-JSON response"
+                )
                 logger.warning(f"Session expired ({reason})")
                 if auth_failures > MAX_AUTH_ATTEMPTS:
-                    raise RuntimeError(f"Max re-auth attempts ({MAX_AUTH_ATTEMPTS}) reached")
+                    raise RuntimeError(
+                        f"Max re-auth attempts ({MAX_AUTH_ATTEMPTS}) reached"
+                    )
                 self._session = self._reauth(auth_failures - 1)
                 self._requests_since_csrf = 0
                 continue
@@ -406,7 +422,9 @@ class XylemDatalakeAdapter(BaseAMIAdapter):
         """Re-authenticate with backoff."""
         if consecutive_failures > 0:
             delay = AUTH_BACKOFF_BASE * (2 ** (consecutive_failures - 1))
-            logger.info(f"Backing off {delay}s (failed attempt {consecutive_failures}/{MAX_AUTH_ATTEMPTS})")
+            logger.info(
+                f"Backing off {delay}s (failed attempt {consecutive_failures}/{MAX_AUTH_ATTEMPTS})"
+            )
             time.sleep(delay)
         else:
             logger.info("Re-authenticating")
@@ -450,7 +468,9 @@ class XylemDatalakeAdapter(BaseAMIAdapter):
         meters = {}
         for device_id, account in accounts_by_device_id.items():
             if account.commodity != "WATER":
-                logger.info(f"Skipping non-water account {device_id} (commodity={account.commodity})")
+                logger.info(
+                    f"Skipping non-water account {device_id} (commodity={account.commodity})"
+                )
                 continue
 
             meter = GeneralMeter(
@@ -461,7 +481,11 @@ class XylemDatalakeAdapter(BaseAMIAdapter):
                 meter_id=device_id,
                 endpoint_id=account.radio_id,
                 meter_install_date=None,
-                meter_size=self.map_meter_size(str(account.meter_size)) if account.meter_size is not None else None,
+                meter_size=(
+                    self.map_meter_size(str(account.meter_size))
+                    if account.meter_size is not None
+                    else None
+                ),
                 meter_manufacturer=account.meter_manufacturer,
                 multiplier=account.display_multiplier,
                 location_address=account.asset_address,
@@ -590,7 +614,9 @@ class XylemDatalakeRawAccountLoader(RawSnowflakeTableLoader):
         return ["device_id"]
 
     def prepare_raw_data(self, extract_outputs):
-        raw_data = extract_outputs.load_from_file("account.json", DatalakeAccount, allow_empty=True)
+        raw_data = extract_outputs.load_from_file(
+            "account.json", DatalakeAccount, allow_empty=True
+        )
         return [
             tuple(i.__getattribute__(name) for name in self.columns()) for i in raw_data
         ]

--- a/amiadapters/adapters/xylem_datalake.py
+++ b/amiadapters/adapters/xylem_datalake.py
@@ -1,0 +1,645 @@
+"""
+Xylem Data Lake adapter.
+
+Fetches AMI data from Xylem's Data Lake platform (Apache Superset over Redshift)
+via the Superset SQL Lab API. Authentication is via Keycloak PKCE OAuth.
+
+The Data Lake exposes per-agency schemas (e.g., sensus_dm_hlsbo) containing:
+  - account: meter/account metadata (current state)
+  - water_intervals: per-interval consumption reads
+  - water_registers: cumulative register reads
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import secrets
+import time
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta
+from typing import Dict, List, Set, Tuple
+
+import requests
+from bs4 import BeautifulSoup
+
+from amiadapters.adapters.base import BaseAMIAdapter, ScheduledExtract
+from amiadapters.models import DataclassJSONEncoder, GeneralMeter, GeneralMeterRead
+from amiadapters.outputs.base import ExtractOutput
+from amiadapters.storage.snowflake import RawSnowflakeLoader, RawSnowflakeTableLoader
+
+logger = logging.getLogger(__name__)
+
+
+# ── Raw dataclasses ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class DatalakeAccount:
+    device_id: str
+    commodity: str
+    device_type: str
+    radio_id: str
+    account_id: str
+    account_name: str
+    account_rate_code: str
+    account_service_type: str
+    account_status: str
+    asset_address: str
+    asset_city: str
+    asset_state: str
+    asset_zip: str
+    meter_manufacturer: str
+    meter_size: str
+    display_multiplier: str
+    sdp_id: str
+    record_active_flag: str
+
+
+@dataclass
+class DatalakeWaterInterval:
+    meter_id: str
+    radio_id: str
+    commodity: str
+    unit_of_measure: str
+    read_time_timestamp: str
+    rni_multiplier: str
+    interval_value: str
+    read_time_timestamp_local: str
+
+
+@dataclass
+class DatalakeWaterRegister:
+    meter_id: str
+    radio_id: str
+    commodity: str
+    unit_of_measure: str
+    read_time_timestamp: str
+    read_quality: str
+    flag: str
+    rni_multiplier: str
+    register_value: str
+    read_time_timestamp_local: str
+
+
+# ── Superset Auth ───────────────────────────────────────────────────────────
+
+
+KEYCLOAK_BASE = "https://cloud.xylem.com/xgs/auth/realms/xgsum"
+
+# Tuning
+DELAY_SECONDS = 2
+MAX_AUTH_ATTEMPTS = 3
+AUTH_BACKOFF_BASE = 10
+CSRF_REFRESH_INTERVAL = 10
+
+
+def _create_superset_session(
+    datalake_url: str,
+    superset_url: str,
+    client_id: str,
+    username: str,
+    password: str,
+) -> requests.Session:
+    """Keycloak PKCE OAuth -> Xylem Data Lake -> Superset session."""
+    session = requests.Session()
+    session.headers.update({
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/145.0.0.0 Safari/537.36"
+        ),
+    })
+
+    code_verifier = secrets.token_urlsafe(32)
+    code_challenge = (
+        base64.urlsafe_b64encode(
+            hashlib.sha256(code_verifier.encode()).digest()
+        )
+        .rstrip(b"=")
+        .decode()
+    )
+
+    # Step 1: Keycloak authorize
+    logger.info("Keycloak authorize")
+    resp = session.get(
+        f"{KEYCLOAK_BASE}/protocol/openid-connect/auth",
+        params={
+            "client_id": client_id,
+            "redirect_uri": f"{datalake_url}/authorize",
+            "response_type": "code",
+            "scope": "openid email profile roles offline_access",
+            "nonce": secrets.token_hex(24),
+            "state": secrets.token_urlsafe(32),
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        },
+        allow_redirects=True,
+    )
+    resp.raise_for_status()
+    if "username" not in resp.text.lower():
+        raise RuntimeError(f"Expected login page, got: {resp.url}")
+
+    # Step 2+3: Submit credentials
+    soup = BeautifulSoup(resp.text, "html.parser")
+    form = soup.find("form", {"id": "kc-form-login"})
+    if not form:
+        raise RuntimeError("No login form found")
+
+    action_url = form.get("action")
+    hidden_fields = {
+        h["name"]: h.get("value", "")
+        for h in form.find_all("input", {"type": "hidden"})
+        if h.get("name")
+    }
+    password_field = form.find("input", {"name": "password"})
+
+    if password_field:
+        logger.info("Submitting credentials (single form)")
+        form_data = {**hidden_fields, "username": username, "password": password}
+        resp = session.post(action_url, data=form_data, allow_redirects=True)
+        resp.raise_for_status()
+    else:
+        logger.info("Submitting email")
+        form_data = {**hidden_fields, "username": username}
+        resp = session.post(action_url, data=form_data, allow_redirects=True)
+        resp.raise_for_status()
+
+        logger.info("Submitting password")
+        soup = BeautifulSoup(resp.text, "html.parser")
+        form = soup.find("form", {"id": "kc-form-login"})
+        if not form:
+            raise RuntimeError("No password form found")
+        action_url = form.get("action")
+        hidden_fields = {
+            h["name"]: h.get("value", "")
+            for h in form.find_all("input", {"type": "hidden"})
+            if h.get("name")
+        }
+        form_data = {**hidden_fields, "username": username, "password": password}
+        resp = session.post(action_url, data=form_data, allow_redirects=True)
+        resp.raise_for_status()
+
+    # Step 4: Superset OAuth
+    logger.info("Superset OAuth")
+    resp = session.get(f"{superset_url}/login/", allow_redirects=True)
+    resp.raise_for_status()
+
+    me_resp = session.get(f"{superset_url}/api/v1/me/")
+    if "application/json" not in me_resp.headers.get("Content-Type", ""):
+        raise RuntimeError(
+            f"Superset login failed (status {me_resp.status_code}): {me_resp.text[:300]}"
+        )
+    user = me_resp.json()["result"]
+    logger.info(f"Authenticated as {user['username']}")
+
+    # Step 5: CSRF token
+    _refresh_csrf(session, superset_url)
+
+    return session
+
+
+def _refresh_csrf(session: requests.Session, superset_url: str) -> None:
+    """Refresh the CSRF token on an existing session."""
+    csrf_resp = session.get(
+        f"{superset_url}/api/v1/security/csrf_token/",
+        allow_redirects=False,
+    )
+    if csrf_resp.status_code == 200 and "application/json" in csrf_resp.headers.get("Content-Type", ""):
+        session.headers["X-CSRFToken"] = csrf_resp.json()["result"]
+        session.headers["Referer"] = f"{superset_url}/sqllab/"
+        logger.info("CSRF token refreshed")
+    else:
+        logger.warning("CSRF token refresh failed — POSTs may fail")
+
+
+def _session_expired(resp: requests.Response) -> bool:
+    """Check if a response indicates an expired session."""
+    if resp.status_code in (301, 302, 303, 307, 308, 401, 403):
+        return True
+    if "application/json" not in resp.headers.get("Content-Type", ""):
+        return True
+    return False
+
+
+# ── Adapter ─────────────────────────────────────────────────────────────────
+
+
+class XylemDatalakeAdapter(BaseAMIAdapter):
+    """
+    AMI Adapter that retrieves data from a Xylem Data Lake instance via the
+    Superset SQL Lab API. Each Data Lake instance is per-agency, identified
+    by an agency_code that determines the URL subdomain and Redshift schema.
+    """
+
+    def __init__(
+        self,
+        org_id,
+        org_timezone,
+        pipeline_configuration,
+        configured_task_output_controller,
+        configured_metrics,
+        agency_code,
+        database_id,
+        client_id,
+        username,
+        password,
+        chunk_hours=12,
+        configured_sinks=None,
+    ):
+        self.agency_code = agency_code
+        self.database_id = database_id
+        self.client_id = client_id
+        self.username = username
+        self.password = password
+        self.chunk_hours = chunk_hours
+        self.datalake_url = f"https://{agency_code}.datalake.xylem-vue.com"
+        self.superset_url = f"https://{agency_code}.superset.datalake.xylem-vue.com"
+        self.schema = f"sensus_dm_{agency_code}"
+        super().__init__(
+            org_id,
+            org_timezone,
+            pipeline_configuration,
+            configured_task_output_controller,
+            configured_metrics,
+            configured_sinks,
+            XYLEM_DATALAKE_RAW_SNOWFLAKE_LOADER,
+        )
+
+    def name(self) -> str:
+        return f"xylem-datalake-{self.org_id}"
+
+    def scheduled_extracts(self) -> List[ScheduledExtract]:
+        return [
+            ScheduledExtract(
+                interval=timedelta(days=6),
+            )
+        ]
+
+    # ── Extract ─────────────────────────────────────────────────────────
+
+    def _extract(
+        self,
+        run_id: str,
+        extract_range_start: datetime,
+        extract_range_end: datetime,
+    ) -> ExtractOutput:
+        self._session = _create_superset_session(
+            self.datalake_url,
+            self.superset_url,
+            self.client_id,
+            self.username,
+            self.password,
+        )
+        self._requests_since_csrf = 0
+
+        account_columns = ", ".join(DatalakeAccount.__dataclass_fields__.keys())
+        account_rows = self._query(
+            f"SELECT {account_columns} FROM {self.schema}.account "
+            f"WHERE record_active_flag = 'true'",
+        )
+
+        interval_columns = ", ".join(DatalakeWaterInterval.__dataclass_fields__.keys())
+        interval_rows = self._query_chunked(
+            f"{self.schema}.water_intervals",
+            interval_columns,
+            "read_time_timestamp",
+            extract_range_start,
+            extract_range_end,
+        )
+
+        register_columns = ", ".join(DatalakeWaterRegister.__dataclass_fields__.keys())
+        register_rows = self._query_chunked(
+            f"{self.schema}.water_registers",
+            register_columns,
+            "read_time_timestamp",
+            extract_range_start,
+            extract_range_end,
+        )
+
+        files = {
+            "account.json": "\n".join(
+                json.dumps(r, cls=DataclassJSONEncoder) for r in account_rows
+            ),
+            "water_intervals.json": "\n".join(
+                json.dumps(r, cls=DataclassJSONEncoder) for r in interval_rows
+            ),
+            "water_registers.json": "\n".join(
+                json.dumps(r, cls=DataclassJSONEncoder) for r in register_rows
+            ),
+        }
+        return ExtractOutput(files)
+
+    def _query_chunked(
+        self,
+        table: str,
+        columns: str,
+        date_column: str,
+        range_start: datetime,
+        range_end: datetime,
+    ) -> List[dict]:
+        """Query a table in time-based chunks to avoid Superset row limits."""
+        all_rows = []
+        current_end = range_end
+        while current_end > range_start:
+            current_start = max(current_end - timedelta(hours=self.chunk_hours), range_start)
+            sql = (
+                f"SELECT {columns} FROM {table} "
+                f"WHERE {date_column} >= '{current_start:%Y-%m-%d %H:%M:%S}' "
+                f"AND {date_column} < '{current_end:%Y-%m-%d %H:%M:%S}'"
+            )
+            rows = self._query(sql)
+            all_rows.extend(rows)
+            current_end = current_start
+        return all_rows
+
+    def _query(self, sql: str) -> List[dict]:
+        """Execute a SQL query via the Superset SQL Lab API with session management."""
+        auth_failures = 0
+
+        while True:
+            # Refresh CSRF periodically
+            self._requests_since_csrf += 1
+            if self._requests_since_csrf >= CSRF_REFRESH_INTERVAL:
+                _refresh_csrf(self._session, self.superset_url)
+                self._requests_since_csrf = 0
+
+            try:
+                resp = self._session.post(
+                    f"{self.superset_url}/api/v1/sqllab/execute/",
+                    json={"database_id": self.database_id, "sql": sql, "runAsync": False},
+                    allow_redirects=False,
+                )
+            except requests.exceptions.TooManyRedirects:
+                auth_failures += 1
+                logger.warning("Redirect loop (session expired)")
+                if auth_failures > MAX_AUTH_ATTEMPTS:
+                    raise RuntimeError(f"Max re-auth attempts ({MAX_AUTH_ATTEMPTS}) reached")
+                self._session = self._reauth(auth_failures - 1)
+                self._requests_since_csrf = 0
+                continue
+
+            if _session_expired(resp):
+                auth_failures += 1
+                reason = f"HTTP {resp.status_code}" if resp.status_code != 200 else "non-JSON response"
+                logger.warning(f"Session expired ({reason})")
+                if auth_failures > MAX_AUTH_ATTEMPTS:
+                    raise RuntimeError(f"Max re-auth attempts ({MAX_AUTH_ATTEMPTS}) reached")
+                self._session = self._reauth(auth_failures - 1)
+                self._requests_since_csrf = 0
+                continue
+
+            resp.raise_for_status()
+            result = resp.json()
+            auth_failures = 0
+
+            if result.get("status") == "error":
+                msg = result.get("error") or result.get("message") or "unknown"
+                raise RuntimeError(f"Superset query error: {msg}")
+
+            rows = result.get("data", [])
+            logger.info(f"Query returned {len(rows)} rows")
+            time.sleep(DELAY_SECONDS)
+            return rows
+
+    def _reauth(self, consecutive_failures: int) -> requests.Session:
+        """Re-authenticate with backoff."""
+        if consecutive_failures > 0:
+            delay = AUTH_BACKOFF_BASE * (2 ** (consecutive_failures - 1))
+            logger.info(f"Backing off {delay}s (failed attempt {consecutive_failures}/{MAX_AUTH_ATTEMPTS})")
+            time.sleep(delay)
+        else:
+            logger.info("Re-authenticating")
+        return _create_superset_session(
+            self.datalake_url,
+            self.superset_url,
+            self.client_id,
+            self.username,
+            self.password,
+        )
+
+    # ── Transform ───────────────────────────────────────────────────────
+
+    def _transform(
+        self, run_id: str, extract_outputs: ExtractOutput
+    ) -> Tuple[List[GeneralMeter], List[GeneralMeterRead]]:
+        accounts_by_device_id = self._accounts_by_device_id(extract_outputs)
+
+        raw_intervals = self._read_file(
+            extract_outputs, "water_intervals.json", DatalakeWaterInterval
+        )
+        raw_registers = self._read_file(
+            extract_outputs, "water_registers.json", DatalakeWaterRegister
+        )
+
+        meters_by_device_id = self._transform_meters(accounts_by_device_id)
+
+        reads = self._transform_reads(
+            accounts_by_device_id,
+            set(meters_by_device_id.keys()),
+            list(raw_intervals),
+            list(raw_registers),
+        )
+
+        return list(meters_by_device_id.values()), reads
+
+    def _transform_meters(
+        self,
+        accounts_by_device_id: Dict[str, DatalakeAccount],
+    ) -> Dict[str, GeneralMeter]:
+        meters = {}
+        for device_id, account in accounts_by_device_id.items():
+            if account.commodity != "WATER":
+                logger.info(f"Skipping non-water account {device_id} (commodity={account.commodity})")
+                continue
+
+            meter = GeneralMeter(
+                org_id=self.org_id,
+                device_id=device_id,
+                account_id=account.account_id,
+                location_id=account.sdp_id,
+                meter_id=device_id,
+                endpoint_id=account.radio_id,
+                meter_install_date=None,
+                meter_size=self.map_meter_size(str(account.meter_size)) if account.meter_size is not None else None,
+                meter_manufacturer=account.meter_manufacturer,
+                multiplier=account.display_multiplier,
+                location_address=account.asset_address,
+                location_city=account.asset_city,
+                location_state=account.asset_state,
+                location_zip=account.asset_zip,
+            )
+            meters[device_id] = meter
+        return meters
+
+    def _transform_reads(
+        self,
+        accounts_by_device_id: Dict[str, DatalakeAccount],
+        meter_ids_to_include: Set[str],
+        interval_reads: List[DatalakeWaterInterval],
+        register_reads: List[DatalakeWaterRegister],
+    ) -> List[GeneralMeterRead]:
+        reads_by_device_and_time = {}
+
+        for raw_read in interval_reads:
+            device_id = raw_read.meter_id
+            if device_id not in meter_ids_to_include:
+                continue
+
+            flowtime = self._parse_flowtime(raw_read.read_time_timestamp)
+            interval_value, interval_unit = self.map_reading(
+                float(raw_read.interval_value),
+                raw_read.unit_of_measure,
+            )
+
+            account = accounts_by_device_id.get(device_id)
+            read = GeneralMeterRead(
+                org_id=self.org_id,
+                device_id=device_id,
+                account_id=account.account_id if account else None,
+                location_id=account.sdp_id if account else None,
+                flowtime=flowtime,
+                register_value=None,
+                register_unit=None,
+                interval_value=interval_value,
+                interval_unit=interval_unit,
+                battery=None,
+                install_date=None,
+                connection=None,
+                estimated=None,
+            )
+            reads_by_device_and_time[(device_id, flowtime)] = read
+
+        for raw_read in register_reads:
+            device_id = raw_read.meter_id
+            if device_id not in meter_ids_to_include:
+                continue
+
+            flowtime = self._parse_flowtime(raw_read.read_time_timestamp)
+            register_value, register_unit = self.map_reading(
+                float(raw_read.register_value),
+                raw_read.unit_of_measure,
+            )
+
+            if (device_id, flowtime) in reads_by_device_and_time:
+                existing_read = reads_by_device_and_time[(device_id, flowtime)]
+                read = replace(
+                    existing_read,
+                    register_value=register_value,
+                    register_unit=register_unit,
+                )
+            else:
+                account = accounts_by_device_id.get(device_id)
+                read = GeneralMeterRead(
+                    org_id=self.org_id,
+                    device_id=device_id,
+                    account_id=account.account_id if account else None,
+                    location_id=account.sdp_id if account else None,
+                    flowtime=flowtime,
+                    register_value=register_value,
+                    register_unit=register_unit,
+                    interval_value=None,
+                    interval_unit=None,
+                    battery=None,
+                    install_date=None,
+                    connection=None,
+                    estimated=None,
+                )
+            reads_by_device_and_time[(device_id, flowtime)] = read
+
+        return list(reads_by_device_and_time.values())
+
+    def _parse_flowtime(self, raw_flowtime: str) -> datetime:
+        """Parse a UTC timestamp from the Data Lake. Timestamps are naive but represent UTC."""
+        if "T" in raw_flowtime:
+            return datetime.strptime(raw_flowtime, "%Y-%m-%dT%H:%M:%S")
+        else:
+            return datetime.strptime(raw_flowtime, "%Y-%m-%d %H:%M:%S")
+
+    # ── Helpers ─────────────────────────────────────────────────────────
+
+    def _accounts_by_device_id(
+        self, extract_outputs: ExtractOutput
+    ) -> Dict[str, DatalakeAccount]:
+        raw_accounts = self._read_file(extract_outputs, "account.json", DatalakeAccount)
+        result = {}
+        for account in raw_accounts:
+            if not account.device_id:
+                logger.warning(f"Skipping account with null device_id: {account}")
+                continue
+            result[account.device_id] = account
+        return result
+
+    def _read_file(self, extract_outputs: ExtractOutput, file: str, raw_dataclass):
+        lines = extract_outputs.load_from_file(file, raw_dataclass, allow_empty=True)
+        yield from lines
+
+
+# ── Raw Snowflake Loaders ───────────────────────────────────────────────────
+
+
+class XylemDatalakeRawAccountLoader(RawSnowflakeTableLoader):
+
+    def table_name(self) -> str:
+        return "XYLEM_DATALAKE_ACCOUNT_BASE"
+
+    def columns(self) -> List[str]:
+        return list(DatalakeAccount.__dataclass_fields__.keys())
+
+    def unique_by(self) -> List[str]:
+        return ["device_id"]
+
+    def prepare_raw_data(self, extract_outputs):
+        raw_data = extract_outputs.load_from_file("account.json", DatalakeAccount, allow_empty=True)
+        return [
+            tuple(i.__getattribute__(name) for name in self.columns()) for i in raw_data
+        ]
+
+
+class XylemDatalakeRawWaterIntervalsLoader(RawSnowflakeTableLoader):
+
+    def table_name(self) -> str:
+        return "XYLEM_DATALAKE_WATER_INTERVALS_BASE"
+
+    def columns(self) -> List[str]:
+        return list(DatalakeWaterInterval.__dataclass_fields__.keys())
+
+    def unique_by(self) -> List[str]:
+        return ["meter_id", "read_time_timestamp"]
+
+    def prepare_raw_data(self, extract_outputs):
+        raw_data = extract_outputs.load_from_file(
+            "water_intervals.json", DatalakeWaterInterval, allow_empty=True
+        )
+        return [
+            tuple(i.__getattribute__(name) for name in self.columns()) for i in raw_data
+        ]
+
+
+class XylemDatalakeRawWaterRegistersLoader(RawSnowflakeTableLoader):
+
+    def table_name(self) -> str:
+        return "XYLEM_DATALAKE_WATER_REGISTERS_BASE"
+
+    def columns(self) -> List[str]:
+        return list(DatalakeWaterRegister.__dataclass_fields__.keys())
+
+    def unique_by(self) -> List[str]:
+        return ["meter_id", "read_time_timestamp"]
+
+    def prepare_raw_data(self, extract_outputs):
+        raw_data = extract_outputs.load_from_file(
+            "water_registers.json", DatalakeWaterRegister, allow_empty=True
+        )
+        return [
+            tuple(i.__getattribute__(name) for name in self.columns()) for i in raw_data
+        ]
+
+
+XYLEM_DATALAKE_RAW_SNOWFLAKE_LOADER = RawSnowflakeLoader.with_table_loaders(
+    [
+        XylemDatalakeRawAccountLoader(),
+        XylemDatalakeRawWaterIntervalsLoader(),
+        XylemDatalakeRawWaterRegistersLoader(),
+    ]
+)

--- a/amiadapters/config.py
+++ b/amiadapters/config.py
@@ -11,6 +11,7 @@ from amiadapters.adapters.beacon import Beacon360Adapter
 from amiadapters.adapters.metersense import MetersenseAdapter
 from amiadapters.adapters.sentryx import SentryxAdapter
 from amiadapters.adapters.subeca import SubecaAdapter
+from amiadapters.adapters.xylem_datalake import XylemDatalakeAdapter
 from amiadapters.adapters.xylem_moulton_niguel import XylemMoultonNiguelAdapter
 from amiadapters.adapters.xylem_sensus import XylemSensusAdapter
 from amiadapters.alerts.base import AmiConnectDagFailureNotifier
@@ -364,6 +365,23 @@ class AMIAdapterConfiguration:
                             source.task_output_controller,
                             source.metrics,
                             source.sinks,
+                        )
+                    )
+                case ConfiguredAMISourceTypes.XYLEM_DATALAKE.value.type:
+                    adapters.append(
+                        XylemDatalakeAdapter(
+                            source.org_id,
+                            source.timezone,
+                            self._pipeline_configuration,
+                            source.task_output_controller,
+                            source.metrics,
+                            agency_code=source.agency_code,
+                            database_id=source.database_id,
+                            client_id=source.client_id,
+                            username=source.secrets.username,
+                            password=source.secrets.password,
+                            chunk_hours=source.chunk_hours,
+                            configured_sinks=source.sinks,
                         )
                     )
                 case ConfiguredAMISourceTypes.XYLEM_MOULTON_NIGUEL.value.type:

--- a/amiadapters/configuration/models.py
+++ b/amiadapters/configuration/models.py
@@ -274,6 +274,12 @@ class XylemMoultonNiguelSecrets(SourceSecretsBase):
 
 
 @dataclass
+class XylemDatalakeSecrets(SourceSecretsBase):
+    username: str
+    password: str
+
+
+@dataclass
 class XylemSensusSecrets(SourceSecretsBase):
     sftp_user: str
     sftp_password: str
@@ -591,6 +597,22 @@ class SubecaSourceConfig(SourceConfigBase):
 
 
 @dataclass(frozen=True)
+class XylemDatalakeSourceConfig(SourceConfigBase):
+    agency_code: str
+    database_id: int
+    client_id: str
+    chunk_hours: int = 12
+
+    def validate(self):
+        super().validate()
+        self._require(
+            "agency_code",
+            "database_id",
+            "client_id",
+        )
+
+
+@dataclass(frozen=True)
 class XylemSensusSourceConfig(SourceConfigBase):
     sftp_host: str
     sftp_remote_data_directory: str
@@ -664,6 +686,12 @@ class ConfiguredAMISourceTypes(Enum):
         "xylem_moulton_niguel",
         XylemMoultonNiguelSourceConfig,
         XylemMoultonNiguelSecrets,
+        [ConfiguredStorageSinkType.SNOWFLAKE],
+    )
+    XYLEM_DATALAKE = SourceSchema(
+        "xylem_datalake",
+        XylemDatalakeSourceConfig,
+        XylemDatalakeSecrets,
         [ConfiguredStorageSinkType.SNOWFLAKE],
     )
     XYLEM_SENSUS = SourceSchema(

--- a/docs/adapters/xylem_datalake.md
+++ b/docs/adapters/xylem_datalake.md
@@ -1,0 +1,41 @@
+# Xylem Data Lake
+
+The Xylem Data Lake adapter retrieves AMI data from Xylem's Data Lake platform via the Apache Superset SQL Lab API. Authentication uses Keycloak PKCE OAuth. Each Data Lake instance is per-agency, identified by an agency code that determines the URL subdomain and Redshift schema.
+
+## Data Sources
+
+The adapter extracts from three tables in the `sensus_dm_{agency_code}` schema:
+
+- **account** — meter/account metadata (active records only)
+- **water_intervals** — per-interval consumption reads
+- **water_registers** — cumulative register reads
+
+Reads join to accounts via `meter_id = device_id` (direct join, no intermediate table needed).
+
+## Configuration
+
+- agency_code: Agency identifier that determines the Data Lake subdomain and schema (e.g., "hlsbo" for Hillsborough)
+- database_id: Superset database ID (e.g., 1)
+- client_id: Keycloak OAuth client ID
+- chunk_hours: Hours per query chunk to avoid Superset row limits (default: 12)
+
+Example:
+```
+python cli.py config add-source my_utility xylem_datalake America/Los_Angeles --config agency-code=hlsbo --config database-id=1 --config client-id=e4b8a1bf-51c5-4ba4-a8e6-15e5186d503e --sinks my_snowflake
+```
+
+## Secrets
+
+- username: Xylem Data Lake login email
+- password: Xylem Data Lake login password
+
+Example:
+```
+python cli.py config update-secret my_utility --source-type xylem_datalake --secret username=user@example.com --secret password=mypassword
+```
+
+## Limitations
+
+- Authentication is via browser-style Keycloak PKCE flow (username/password). Xylem has announced upcoming MFA requirements which may require changes to the auth mechanism.
+- Only active account records are extracted. Deep backfills may need historical account data for correct metadata attribution.
+- Meter size values from the Data Lake use Sensus internal codes (e.g., 402) which don't map to the standard size lookup. Meters are created with meter_size=None in these cases.

--- a/test/amiadapters/test_xylem_datalake.py
+++ b/test/amiadapters/test_xylem_datalake.py
@@ -1,0 +1,242 @@
+import json
+
+from amiadapters.outputs.base import ExtractOutput
+from amiadapters.models import DataclassJSONEncoder, GeneralMeter, GeneralMeterRead
+from amiadapters.adapters.xylem_datalake import (
+    XylemDatalakeAdapter,
+    DatalakeAccount,
+    DatalakeWaterInterval,
+    DatalakeWaterRegister,
+)
+from test.base_test_case import BaseTestCase
+
+
+def _make_account(**overrides):
+    defaults = {
+        "device_id": "74931234",
+        "commodity": "WATER",
+        "device_type": "METER",
+        "radio_id": "86577068",
+        "account_id": "1818",
+        "account_name": "TEST CUSTOMER",
+        "account_rate_code": "020",
+        "account_service_type": "R",
+        "account_status": "ACTIVE",
+        "asset_address": "851 IRWIN DR",
+        "asset_city": "HILLSBOROUGH",
+        "asset_state": "CA",
+        "asset_zip": "94010",
+        "meter_manufacturer": "SE",
+        "meter_size": 1.5,
+        "display_multiplier": 1,
+        "sdp_id": "030-100-010",
+        "record_active_flag": "true",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _make_interval(**overrides):
+    defaults = {
+        "meter_id": "74931234",
+        "radio_id": "86577068",
+        "commodity": "WATER",
+        "unit_of_measure": "CF",
+        "read_time_timestamp": "2026-04-14T08:00:00",
+        "rni_multiplier": "1",
+        "interval_value": "3",
+        "read_time_timestamp_local": "2026-04-14T01:00:00",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _make_register(**overrides):
+    defaults = {
+        "meter_id": "74931234",
+        "radio_id": "86577068",
+        "commodity": "WATER",
+        "unit_of_measure": "CF",
+        "read_time_timestamp": "2026-04-14T08:00:00",
+        "read_quality": "R",
+        "flag": "",
+        "rni_multiplier": "1",
+        "register_value": "59727",
+        "read_time_timestamp_local": "2026-04-14T01:00:00",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _build_extract_output(accounts, intervals, registers):
+    return ExtractOutput(
+        {
+            "account.json": "\n".join(
+                json.dumps(a, cls=DataclassJSONEncoder) for a in accounts
+            ),
+            "water_intervals.json": "\n".join(
+                json.dumps(i, cls=DataclassJSONEncoder) for i in intervals
+            ),
+            "water_registers.json": "\n".join(
+                json.dumps(r, cls=DataclassJSONEncoder) for r in registers
+            ),
+        }
+    )
+
+
+class TestXylemDatalakeAdapter(BaseTestCase):
+    def setUp(self):
+        self.adapter = XylemDatalakeAdapter(
+            org_id="test_org",
+            org_timezone="America/Los_Angeles",
+            pipeline_configuration=None,
+            configured_task_output_controller=self.TEST_TASK_OUTPUT_CONTROLLER_CONFIGURATION,
+            configured_metrics=self.TEST_METRICS_CONFIGURATION,
+            agency_code="hlsbo",
+            database_id=1,
+            client_id="test-client-id",
+            username="test",
+            password="test",
+            configured_sinks=[],
+        )
+
+    def test_transform_basic(self):
+        extract = _build_extract_output(
+            [_make_account()],
+            [_make_interval()],
+            [_make_register()],
+        )
+        meters, reads = self.adapter._transform("run1", extract)
+
+        self.assertEqual(len(meters), 1)
+        self.assertIsInstance(meters[0], GeneralMeter)
+        self.assertEqual(meters[0].device_id, "74931234")
+        self.assertEqual(meters[0].meter_id, "74931234")
+        self.assertEqual(meters[0].account_id, "1818")
+        self.assertEqual(meters[0].location_id, "030-100-010")
+        self.assertEqual(meters[0].endpoint_id, "86577068")
+        self.assertEqual(meters[0].location_address, "851 IRWIN DR")
+        self.assertEqual(meters[0].location_city, "HILLSBOROUGH")
+        self.assertEqual(meters[0].location_state, "CA")
+
+        self.assertEqual(len(reads), 1)
+        self.assertIsInstance(reads[0], GeneralMeterRead)
+        self.assertEqual(reads[0].device_id, "74931234")
+        self.assertEqual(reads[0].account_id, "1818")
+        self.assertEqual(reads[0].interval_value, 3.0)
+        self.assertEqual(reads[0].register_value, 59727.0)
+
+    def test_transform_interval_only(self):
+        extract = _build_extract_output(
+            [_make_account()],
+            [_make_interval()],
+            [],
+        )
+        meters, reads = self.adapter._transform("run1", extract)
+
+        self.assertEqual(len(reads), 1)
+        self.assertEqual(reads[0].interval_value, 3.0)
+        self.assertIsNone(reads[0].register_value)
+
+    def test_transform_register_only(self):
+        extract = _build_extract_output(
+            [_make_account()],
+            [],
+            [_make_register()],
+        )
+        meters, reads = self.adapter._transform("run1", extract)
+
+        self.assertEqual(len(reads), 1)
+        self.assertIsNone(reads[0].interval_value)
+        self.assertEqual(reads[0].register_value, 59727.0)
+
+    def test_transform_joins_interval_and_register_by_device_and_time(self):
+        extract = _build_extract_output(
+            [_make_account()],
+            [_make_interval()],
+            [_make_register()],
+        )
+        meters, reads = self.adapter._transform("run1", extract)
+
+        self.assertEqual(len(reads), 1)
+        self.assertEqual(reads[0].interval_value, 3.0)
+        self.assertEqual(reads[0].register_value, 59727.0)
+
+    def test_transform_does_not_join_different_timestamps(self):
+        extract = _build_extract_output(
+            [_make_account()],
+            [_make_interval(read_time_timestamp="2026-04-14T08:00:00")],
+            [_make_register(read_time_timestamp="2026-04-14T09:00:00")],
+        )
+        meters, reads = self.adapter._transform("run1", extract)
+
+        self.assertEqual(len(reads), 2)
+
+    def test_transform_skips_non_water_accounts(self):
+        extract = _build_extract_output(
+            [_make_account(commodity="ELECTRIC")],
+            [_make_interval()],
+            [],
+        )
+        meters, reads = self.adapter._transform("run1", extract)
+
+        self.assertEqual(len(meters), 0)
+        self.assertEqual(len(reads), 0)
+
+    def test_transform_skips_reads_without_matching_meter(self):
+        extract = _build_extract_output(
+            [_make_account(device_id="99999999")],
+            [_make_interval(meter_id="74931234")],
+            [],
+        )
+        meters, reads = self.adapter._transform("run1", extract)
+
+        self.assertEqual(len(meters), 1)
+        self.assertEqual(len(reads), 0)
+
+    def test_transform_handles_null_account_for_read(self):
+        """Read whose meter_id matches a meter but has no account."""
+        account = _make_account()
+        interval = _make_interval()
+        extract = _build_extract_output([account], [interval], [])
+
+        meters, reads = self.adapter._transform("run1", extract)
+        self.assertEqual(len(reads), 1)
+        self.assertEqual(reads[0].account_id, "1818")
+
+    def test_transform_multiple_meters(self):
+        account1 = _make_account(device_id="111", account_id="A1", radio_id="R1")
+        account2 = _make_account(device_id="222", account_id="A2", radio_id="R2")
+        interval1 = _make_interval(meter_id="111", radio_id="R1")
+        interval2 = _make_interval(meter_id="222", radio_id="R2")
+
+        extract = _build_extract_output(
+            [account1, account2],
+            [interval1, interval2],
+            [],
+        )
+        meters, reads = self.adapter._transform("run1", extract)
+
+        self.assertEqual(len(meters), 2)
+        self.assertEqual(len(reads), 2)
+        device_ids = {m.device_id for m in meters}
+        self.assertEqual(device_ids, {"111", "222"})
+
+    def test_transform_empty_extract(self):
+        extract = _build_extract_output([], [], [])
+        meters, reads = self.adapter._transform("run1", extract)
+
+        self.assertEqual(len(meters), 0)
+        self.assertEqual(len(reads), 0)
+
+    def test_parse_flowtime_with_T(self):
+        from datetime import datetime
+
+        result = self.adapter._parse_flowtime("2026-04-14T08:00:00")
+        self.assertEqual(result, datetime(2026, 4, 14, 8, 0, 0))
+
+    def test_parse_flowtime_with_space(self):
+        from datetime import datetime
+
+        result = self.adapter._parse_flowtime("2026-04-14 08:00:00")
+        self.assertEqual(result, datetime(2026, 4, 14, 8, 0, 0))

--- a/test/amiadapters/test_xylem_datalake.py
+++ b/test/amiadapters/test_xylem_datalake.py
@@ -2,12 +2,7 @@ import json
 
 from amiadapters.outputs.base import ExtractOutput
 from amiadapters.models import DataclassJSONEncoder, GeneralMeter, GeneralMeterRead
-from amiadapters.adapters.xylem_datalake import (
-    XylemDatalakeAdapter,
-    DatalakeAccount,
-    DatalakeWaterInterval,
-    DatalakeWaterRegister,
-)
+from amiadapters.adapters.xylem_datalake import XylemDatalakeAdapter
 from test.base_test_case import BaseTestCase
 
 
@@ -194,8 +189,7 @@ class TestXylemDatalakeAdapter(BaseTestCase):
         self.assertEqual(len(meters), 1)
         self.assertEqual(len(reads), 0)
 
-    def test_transform_handles_null_account_for_read(self):
-        """Read whose meter_id matches a meter but has no account."""
+    def test_transform_populates_account_metadata_on_read(self):
         account = _make_account()
         interval = _make_interval()
         extract = _build_extract_output([account], [interval], [])
@@ -203,6 +197,7 @@ class TestXylemDatalakeAdapter(BaseTestCase):
         meters, reads = self.adapter._transform("run1", extract)
         self.assertEqual(len(reads), 1)
         self.assertEqual(reads[0].account_id, "1818")
+        self.assertEqual(reads[0].location_id, "030-100-010")
 
     def test_transform_multiple_meters(self):
         account1 = _make_account(device_id="111", account_id="A1", radio_id="R1")

--- a/test/fixtures/xylem-datalake-config.yaml
+++ b/test/fixtures/xylem-datalake-config.yaml
@@ -1,0 +1,22 @@
+sources:
+- type: xylem_datalake
+  org_id: cadc_hillsborough
+  timezone: America/Los_Angeles
+  agency_code: hlsbo
+  database_id: 1
+  client_id: e4b8a1bf-51c5-4ba4-a8e6-15e5186d503e
+  chunk_hours: 12
+  sinks:
+  - my_snowflake_instance
+
+sinks:
+- type: snowflake
+  id: my_snowflake_instance
+
+task_output:
+  type: local
+  output_folder: outputs
+
+pipeline:
+  run_post_processors: false
+  should_publish_load_finished_events: false

--- a/test/fixtures/xylem-datalake-secrets.yaml
+++ b/test/fixtures/xylem-datalake-secrets.yaml
@@ -1,0 +1,14 @@
+sources:
+  cadc_hillsborough:
+    username: my_username
+    password: my_password
+
+sinks:
+  my_snowflake_instance:
+    account: my_account
+    user: my_user
+    ssh_key: my_ssh_key
+    role: my_role
+    warehouse: my_warehouse
+    database: my_database
+    schema: my_schema

--- a/test/manual/test_xylem_datalake.py
+++ b/test/manual/test_xylem_datalake.py
@@ -1,0 +1,100 @@
+"""
+Manual end-to-end test for the Xylem Data Lake adapter.
+
+Usage (from repo root):
+    .venv/bin/python -m test.manual.test_xylem_datalake
+
+Requires:
+    - test/fixtures/xylem-datalake-secrets.yaml filled in with real credentials
+    - beautifulsoup4 and requests installed
+
+This script:
+    1. Loads config from YAML fixtures
+    2. Runs extract (authenticates to Data Lake, queries 1 day of data)
+    3. Runs transform (converts raw data to GeneralMeter + GeneralMeterRead)
+    4. Runs load_raw + load_transformed (writes to Snowflake)
+    5. Prints summary stats
+"""
+
+import logging
+import sys
+from datetime import datetime, timedelta
+
+from amiadapters.config import AMIAdapterConfiguration
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    config = AMIAdapterConfiguration.from_yaml(
+        "test/fixtures/xylem-datalake-config.yaml",
+        "test/fixtures/xylem-datalake-secrets.yaml",
+    )
+
+    adapters = config.adapters()
+    if not adapters:
+        logger.error("No adapters created from config. Check your YAML files.")
+        return
+
+    adapter = adapters[0]
+    logger.info(f"Adapter: {adapter.name()}")
+
+    # Extract a small window: 1 day, recent data
+    end = datetime.utcnow()
+    start = end - timedelta(days=1)
+    logger.info(f"Extract range: {start:%Y-%m-%d %H:%M} -> {end:%Y-%m-%d %H:%M}")
+
+    run_id = f"test_{start:%Y%m%d}_{end:%Y%m%d}"
+
+    # Step 1: Extract
+    logger.info("=== EXTRACT ===")
+    adapter.extract_and_output(run_id, start, end)
+
+    # Read back extract outputs to print stats
+    extract_outputs = adapter.output_controller.read_extract_outputs(run_id)
+    for filename, content in extract_outputs.get_outputs().items():
+        lines = content.strip().split("\n") if content.strip() else []
+        logger.info(f"  {filename}: {len(lines)} rows")
+
+    # Step 2: Transform
+    logger.info("=== TRANSFORM ===")
+    adapter.transform_and_output(run_id)
+
+    # Read back transform outputs to print stats
+    meters = adapter.output_controller.read_transformed_meters(run_id)
+    reads = adapter.output_controller.read_transformed_meter_reads(run_id)
+    logger.info(f"  Meters: {len(meters)}")
+    logger.info(f"  Reads: {len(reads)}")
+
+    if meters:
+        m = meters[0]
+        logger.info(f"  Sample meter: device_id={m.device_id} account_id={m.account_id} "
+                     f"location_id={m.location_id} address={m.location_address}")
+    if reads:
+        r = reads[0]
+        logger.info(f"  Sample read: device_id={r.device_id} flowtime={r.flowtime} "
+                     f"interval_value={r.interval_value} register_value={r.register_value}")
+
+    # Step 3: Load to Snowflake
+    logger.info("=== LOAD RAW ===")
+    adapter.load_raw(run_id)
+
+    logger.info("=== LOAD TRANSFORMED ===")
+    adapter.load_transformed(run_id)
+
+    logger.info("=== DONE ===")
+    logger.info("Check Snowflake for:")
+    logger.info("  - XYLEM_DATALAKE_ACCOUNT_BASE")
+    logger.info("  - XYLEM_DATALAKE_WATER_INTERVALS_BASE")
+    logger.info("  - XYLEM_DATALAKE_WATER_REGISTERS_BASE")
+    logger.info("  - METERS")
+    logger.info("  - READINGS")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/test_xylem_datalake.py
+++ b/test/manual/test_xylem_datalake.py
@@ -73,12 +73,16 @@ def main():
 
     if meters:
         m = meters[0]
-        logger.info(f"  Sample meter: device_id={m.device_id} account_id={m.account_id} "
-                     f"location_id={m.location_id} address={m.location_address}")
+        logger.info(
+            f"  Sample meter: device_id={m.device_id} account_id={m.account_id} "
+            f"location_id={m.location_id} address={m.location_address}"
+        )
     if reads:
         r = reads[0]
-        logger.info(f"  Sample read: device_id={r.device_id} flowtime={r.flowtime} "
-                     f"interval_value={r.interval_value} register_value={r.register_value}")
+        logger.info(
+            f"  Sample read: device_id={r.device_id} flowtime={r.flowtime} "
+            f"interval_value={r.interval_value} register_value={r.register_value}"
+        )
 
     # Step 3: Load to Snowflake
     logger.info("=== LOAD RAW ===")


### PR DESCRIPTION
## Summary

- New adapter (`xylem_datalake`) for fetching AMI data from Xylem's Data Lake platform via the Superset SQL Lab API
- Extracts from three tables: `account` (metadata), `water_intervals` (interval reads), `water_registers` (register reads)
- Auth via Keycloak PKCE OAuth with automatic session management, CSRF refresh, and re-auth with exponential backoff on expiry
- Parameterized by `agency_code` — works for any Xylem Data Lake agency (tested with Hillsborough)
- Auth module is designed to be swappable when Xylem rolls out MFA requirements

## Files changed

- `amiadapters/adapters/xylem_datalake.py` — adapter implementation (extract, transform, raw loaders)
- `amiadapters/configuration/models.py` — config and secrets models, enum registration
- `amiadapters/config.py` — factory wiring
- `docs/adapters/xylem_datalake.md` — adapter documentation
- `test/fixtures/xylem-datalake-*.yaml` — local test config fixtures
- `test/manual/test_xylem_datalake.py` — manual end-to-end test script

## Test plan

- [x] Extract tested against Hillsborough Data Lake: 5,147 accounts, 87K interval reads, 87K register reads
- [x] Transform verified: 5,145 meters, 87K reads with correct field mapping
- [x] Session expiry mid-extract handled gracefully (504 → re-auth → resumed)
- [ ] Snowflake load (uses shared load infrastructure, not separately tested)