### PR TITLE
Refactor irrigation events to match leaks pattern

### DIFF
--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -673,31 +673,104 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
             """
             conn.cursor().execute(ami_leaks_agg_sql)
 
-            ami_irrigation_detection_agg_sql = f"""
-                create or replace table irrigation_detection_agg
-                as
-                with cte as
+            # Ensure irrigation detail table exists (no-op after first run)
+            conn.cursor().execute(f"""
+                create table if not exists irrigation_{self.org_id} (
+                    org_id text,
+                    device_id text,
+                    flowtime_ts timestamp_tz,
+                    total_reading_cf float,
+                    irrigation_reading_cf float,
+                    non_irrigation_reading_cf float,
+                    is_irrigation boolean,
+                    event_seq number(18,0),
+                    event_start_ts timestamp_tz,
+                    event_end_ts timestamp_tz,
+                    event_hrs number(10,0),
+                    event_id text
+                )
+            """)
+
+            # Delete existing rows in the window, then insert fresh results
+            conn.cursor().execute(f"""
+                delete from irrigation_{self.org_id}
+                where flowtime_ts >= '{min_date.isoformat()}'
+                and flowtime_ts <= '{max_date.isoformat()}'
+            """)
+
+            ami_irrigation_sql = f"""
+                insert into irrigation_{self.org_id}
+                with source_data as
+                (
+                    select distinct *
+                    from wavelet.global_irrigation_detection
+                    where source = '{self.org_id}'
+                    and timestamp::date >= '{min_date.isoformat()}'
+                    and timestamp::date <= '{max_date.isoformat()}'
+                )
+                , with_events as
+                (
+                    select
+                        source                                as org_id
+                        , device_id
+                        , timestamp::timestamp_tz             as flowtime_ts
+                        , total_reading                       as total_reading_cf
+                        , irrigation_reading                  as irrigation_reading_cf
+                        , non_irrigation_reading              as non_irrigation_reading_cf
+                        , coalesce(irrigation_reading, 0) > 0 as is_irrigation
+                        , conditional_change_event(coalesce(irrigation_reading, 0) = 0)
+                              over (partition by source, device_id order by timestamp) as event_seq
+                    from source_data
+                )
+                , with_event_bounds as
                 (
                     select *
-                        , conditional_change_event(coalesce(irrigation_reading, 0) = 0) over (partition by source, device_id order by timestamp) as grp
-                    from (select distinct * from wavelet.global_irrigation_detection)
+                        , min(flowtime_ts) over (partition by org_id, device_id, event_seq) as event_start_ts
+                        , max(flowtime_ts) over (partition by org_id, device_id, event_seq) as event_end_ts
+                        , datediff(hour, event_start_ts, event_end_ts) + 1                  as event_hrs
+                        , to_varchar(event_start_ts, 'yyyy/mm/dd@hh - ')
+                              || event_hrs
+                              || iff(max(is_irrigation::int) over (partition by org_id, device_id, event_seq) = 1, 'h', 'h*') as event_id
+                    from with_events
                 )
-                select 
-                    source
+                select
+                    org_id
                     , device_id
-                    , min(timestamp) as event_start_ts
-                    , max(timestamp) as event_end_ts
-                    , datediff(hour, event_start_ts, event_end_ts) + 1 as event_hrs
-                    , max(irrigation_reading > 0) is_irrigation
-                    , to_varchar(event_start_ts, 'yyyy/mm/dd@hh - ') || event_hrs || iff(is_irrigation, 'h', 'h*') as event_id
-                    , array_agg(timestamp) within group (order by timestamp) as timestamp
-                    , array_agg(total_reading) within group (order by timestamp) as total_reading_cf
-                    , array_agg(irrigation_reading) within group (order by timestamp) as irrigation_reading_cf
-                    , array_agg(non_irrigation_reading) within group (order by timestamp) as non_irrigation_reading_cf
-                from cte
-                group by source, device_id, grp
+                    , flowtime_ts
+                    , total_reading_cf
+                    , irrigation_reading_cf
+                    , non_irrigation_reading_cf
+                    , is_irrigation
+                    , event_seq
+                    , event_start_ts
+                    , event_end_ts
+                    , event_hrs
+                    , event_id
+                from with_event_bounds
             """
-            conn.cursor().execute(ami_irrigation_detection_agg_sql)
+            conn.cursor().execute(ami_irrigation_sql)
+
+            ami_irrigation_agg_sql = f"""
+                create or replace table irrigation_{self.org_id}_agg
+                as
+                select
+                    org_id
+                    , device_id
+                    , event_id
+                    , event_start_ts
+                    , event_end_ts
+                    , event_hrs
+                    , max(is_irrigation)                                                           as is_irrigation
+                    , array_agg(flowtime_ts) within group (order by flowtime_ts)                   as flowtime_ts
+                    , array_agg(total_reading_cf) within group (order by flowtime_ts)              as total_reading_cf
+                    , array_agg(irrigation_reading_cf) within group (order by flowtime_ts)         as irrigation_reading_cf
+                    , array_agg(non_irrigation_reading_cf) within group (order by flowtime_ts)     as non_irrigation_reading_cf
+                    , sum(total_reading_cf)                                                        as total_reading_sum_cf
+                    , sum(irrigation_reading_cf)                                                   as irrigation_reading_sum_cf
+                from irrigation_{self.org_id}
+                group by org_id, device_id, event_id, event_start_ts, event_end_ts, event_hrs
+            """
+            conn.cursor().execute(ami_irrigation_agg_sql)
 
     def _meter_tuple(self, meter: GeneralMeter, row_active_from: datetime):
         result = [

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -497,8 +497,8 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
             # Delete existing rows in the window, then insert fresh results
             conn.cursor().execute(f"""
                 delete from leaks_{self.org_id}
-                where flowtime_ts >= '{min_date.isoformat()}'
-                and flowtime_ts <= '{max_date.isoformat()}'
+                where flowtime_ts::date >= '{min_date.isoformat()}'
+                and flowtime_ts::date <= '{max_date.isoformat()}'
             """)
 
             ami_leaks_sql = f"""
@@ -694,8 +694,8 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
             # Delete existing rows in the window, then insert fresh results
             conn.cursor().execute(f"""
                 delete from irrigation_{self.org_id}
-                where flowtime_ts >= '{min_date.isoformat()}'
-                and flowtime_ts <= '{max_date.isoformat()}'
+                where flowtime_ts::date >= '{min_date.isoformat()}'
+                and flowtime_ts::date <= '{max_date.isoformat()}'
             """)
 
             ami_irrigation_sql = f"""

--- a/test/amiadapters/storage/test_snowflake.py
+++ b/test/amiadapters/storage/test_snowflake.py
@@ -266,9 +266,7 @@ class TestSnowflakeStorageSink(BaseTestCase):
 
         self.snowflake_sink.exec_postprocessor("run-id", min_date, max_date)
 
-        all_sqls = [
-            call[0][0] for call in self.mock_cursor.execute.call_args_list
-        ]
+        all_sqls = [call[0][0] for call in self.mock_cursor.execute.call_args_list]
         normalized = [self.normalize_sql(sql) for sql in all_sqls]
 
         # Debe haber exactamente 9 execute calls:
@@ -279,7 +277,11 @@ class TestSnowflakeStorageSink(BaseTestCase):
 
         # --- Tabla detalle irrigation ---
         irrigation_create = next(
-            (s for s in normalized if "create table if not exists irrigation_org-id" in s.lower()),
+            (
+                s
+                for s in normalized
+                if "create table if not exists irrigation_org-id" in s.lower()
+            ),
             None,
         )
         self.assertIsNotNone(irrigation_create, "Debe crear tabla irrigation_{org_id}")
@@ -293,7 +295,9 @@ class TestSnowflakeStorageSink(BaseTestCase):
             (s for s in normalized if "delete from irrigation_org-id" in s.lower()),
             None,
         )
-        self.assertIsNotNone(irrigation_delete, "Debe hacer DELETE en irrigation_{org_id}")
+        self.assertIsNotNone(
+            irrigation_delete, "Debe hacer DELETE en irrigation_{org_id}"
+        )
         self.assertIn("2025-01-01", irrigation_delete)
         self.assertIn("2025-01-31", irrigation_delete)
 
@@ -302,7 +306,9 @@ class TestSnowflakeStorageSink(BaseTestCase):
             (s for s in normalized if "insert into irrigation_org-id" in s.lower()),
             None,
         )
-        self.assertIsNotNone(irrigation_insert, "Debe hacer INSERT en irrigation_{org_id}")
+        self.assertIsNotNone(
+            irrigation_insert, "Debe hacer INSERT en irrigation_{org_id}"
+        )
         self.assertIn("wavelet.global_irrigation_detection", irrigation_insert)
         self.assertIn("source = 'org-id'", irrigation_insert)
         self.assertIn("2025-01-01", irrigation_insert)
@@ -313,7 +319,11 @@ class TestSnowflakeStorageSink(BaseTestCase):
 
         # --- Tabla agg ---
         irrigation_agg = next(
-            (s for s in normalized if "create or replace table irrigation_org-id_agg" in s.lower()),
+            (
+                s
+                for s in normalized
+                if "create or replace table irrigation_org-id_agg" in s.lower()
+            ),
             None,
         )
         self.assertIsNotNone(irrigation_agg, "Debe crear tabla irrigation_{org_id}_agg")

--- a/test/amiadapters/storage/test_snowflake.py
+++ b/test/amiadapters/storage/test_snowflake.py
@@ -257,9 +257,9 @@ class TestSnowflakeStorageSink(BaseTestCase):
 
     def test_exec_postprocessor__creates_irrigation_tables_per_org(self):
         """
-        Verifica que exec_postprocessor crea las tablas de irrigation por org
-        con el mismo patron de leaks: CREATE IF NOT EXISTS, DELETE por ventana,
-        INSERT desde wavelet y CREATE OR REPLACE para la tabla agg.
+        Verifies that exec_postprocessor creates per-org irrigation tables
+        following the leaks pattern: CREATE IF NOT EXISTS, DELETE by date window,
+        INSERT from wavelet, and CREATE OR REPLACE for the agg table.
         """
         min_date = datetime.datetime(2025, 1, 1, tzinfo=pytz.UTC)
         max_date = datetime.datetime(2025, 1, 31, tzinfo=pytz.UTC)
@@ -269,13 +269,13 @@ class TestSnowflakeStorageSink(BaseTestCase):
         all_sqls = [call[0][0] for call in self.mock_cursor.execute.call_args_list]
         normalized = [self.normalize_sql(sql) for sql in all_sqls]
 
-        # Debe haber exactamente 9 execute calls:
+        # Expects exactly 9 execute calls:
         # 1 meters_score, 1 leaks CREATE, 1 leaks DELETE, 1 leaks INSERT,
         # 1 leaks_agg, 1 irrigation CREATE, 1 irrigation DELETE,
         # 1 irrigation INSERT, 1 irrigation_agg
         self.assertEqual(9, self.mock_cursor.execute.call_count)
 
-        # --- Tabla detalle irrigation ---
+        # --- irrigation detail table ---
         irrigation_create = next(
             (
                 s
@@ -284,40 +284,42 @@ class TestSnowflakeStorageSink(BaseTestCase):
             ),
             None,
         )
-        self.assertIsNotNone(irrigation_create, "Debe crear tabla irrigation_{org_id}")
+        self.assertIsNotNone(
+            irrigation_create, "Should create irrigation_{org_id} table"
+        )
         self.assertIn("flowtime_ts", irrigation_create)
         self.assertIn("irrigation_reading_cf", irrigation_create)
         self.assertIn("is_irrigation", irrigation_create)
         self.assertIn("event_seq", irrigation_create)
 
-        # --- DELETE por ventana de fechas ---
+        # --- DELETE by date window ---
         irrigation_delete = next(
             (s for s in normalized if "delete from irrigation_org-id" in s.lower()),
             None,
         )
         self.assertIsNotNone(
-            irrigation_delete, "Debe hacer DELETE en irrigation_{org_id}"
+            irrigation_delete, "Should DELETE from irrigation_{org_id}"
         )
         self.assertIn("2025-01-01", irrigation_delete)
         self.assertIn("2025-01-31", irrigation_delete)
 
-        # --- INSERT filtrando por org_id y ventana ---
+        # --- INSERT filtered by org_id and date window ---
         irrigation_insert = next(
             (s for s in normalized if "insert into irrigation_org-id" in s.lower()),
             None,
         )
         self.assertIsNotNone(
-            irrigation_insert, "Debe hacer INSERT en irrigation_{org_id}"
+            irrigation_insert, "Should INSERT into irrigation_{org_id}"
         )
         self.assertIn("wavelet.global_irrigation_detection", irrigation_insert)
         self.assertIn("source = 'org-id'", irrigation_insert)
         self.assertIn("2025-01-01", irrigation_insert)
         self.assertIn("2025-01-31", irrigation_insert)
         self.assertIn("conditional_change_event", irrigation_insert)
-        # columna renombrada de source a org_id
+        # source column renamed to org_id
         self.assertIn("source as org_id", irrigation_insert.lower())
 
-        # --- Tabla agg ---
+        # --- agg table ---
         irrigation_agg = next(
             (
                 s
@@ -326,14 +328,16 @@ class TestSnowflakeStorageSink(BaseTestCase):
             ),
             None,
         )
-        self.assertIsNotNone(irrigation_agg, "Debe crear tabla irrigation_{org_id}_agg")
+        self.assertIsNotNone(
+            irrigation_agg, "Should create irrigation_{org_id}_agg table"
+        )
         self.assertIn("irrigation_reading_sum_cf", irrigation_agg)
         self.assertIn("total_reading_sum_cf", irrigation_agg)
         self.assertNotIn("irrigation_detection_agg", irrigation_agg)
 
     def test_exec_postprocessor__irrigation_tables_not_shared(self):
         """
-        Verifica que NO se crea la tabla compartida vieja irrigation_detection_agg.
+        Verifies that the old shared irrigation_detection_agg table is not created.
         """
         min_date = datetime.datetime(2025, 1, 1, tzinfo=pytz.UTC)
         max_date = datetime.datetime(2025, 1, 31, tzinfo=pytz.UTC)
@@ -346,7 +350,7 @@ class TestSnowflakeStorageSink(BaseTestCase):
         self.assertNotIn(
             "irrigation_detection_agg",
             all_sqls,
-            "No debe crear la tabla compartida vieja irrigation_detection_agg",
+            "Should not create the old shared irrigation_detection_agg table",
         )
 
     def test_store_raw(self):

--- a/test/amiadapters/storage/test_snowflake.py
+++ b/test/amiadapters/storage/test_snowflake.py
@@ -255,6 +255,90 @@ class TestSnowflakeStorageSink(BaseTestCase):
         # Trim leading and trailing whitespace
         return normalized.strip()
 
+    def test_exec_postprocessor__creates_irrigation_tables_per_org(self):
+        """
+        Verifica que exec_postprocessor crea las tablas de irrigation por org
+        con el mismo patron de leaks: CREATE IF NOT EXISTS, DELETE por ventana,
+        INSERT desde wavelet y CREATE OR REPLACE para la tabla agg.
+        """
+        min_date = datetime.datetime(2025, 1, 1, tzinfo=pytz.UTC)
+        max_date = datetime.datetime(2025, 1, 31, tzinfo=pytz.UTC)
+
+        self.snowflake_sink.exec_postprocessor("run-id", min_date, max_date)
+
+        all_sqls = [
+            call[0][0] for call in self.mock_cursor.execute.call_args_list
+        ]
+        normalized = [self.normalize_sql(sql) for sql in all_sqls]
+
+        # Debe haber exactamente 9 execute calls:
+        # 1 meters_score, 1 leaks CREATE, 1 leaks DELETE, 1 leaks INSERT,
+        # 1 leaks_agg, 1 irrigation CREATE, 1 irrigation DELETE,
+        # 1 irrigation INSERT, 1 irrigation_agg
+        self.assertEqual(9, self.mock_cursor.execute.call_count)
+
+        # --- Tabla detalle irrigation ---
+        irrigation_create = next(
+            (s for s in normalized if "create table if not exists irrigation_org-id" in s.lower()),
+            None,
+        )
+        self.assertIsNotNone(irrigation_create, "Debe crear tabla irrigation_{org_id}")
+        self.assertIn("flowtime_ts", irrigation_create)
+        self.assertIn("irrigation_reading_cf", irrigation_create)
+        self.assertIn("is_irrigation", irrigation_create)
+        self.assertIn("event_seq", irrigation_create)
+
+        # --- DELETE por ventana de fechas ---
+        irrigation_delete = next(
+            (s for s in normalized if "delete from irrigation_org-id" in s.lower()),
+            None,
+        )
+        self.assertIsNotNone(irrigation_delete, "Debe hacer DELETE en irrigation_{org_id}")
+        self.assertIn("2025-01-01", irrigation_delete)
+        self.assertIn("2025-01-31", irrigation_delete)
+
+        # --- INSERT filtrando por org_id y ventana ---
+        irrigation_insert = next(
+            (s for s in normalized if "insert into irrigation_org-id" in s.lower()),
+            None,
+        )
+        self.assertIsNotNone(irrigation_insert, "Debe hacer INSERT en irrigation_{org_id}")
+        self.assertIn("wavelet.global_irrigation_detection", irrigation_insert)
+        self.assertIn("source = 'org-id'", irrigation_insert)
+        self.assertIn("2025-01-01", irrigation_insert)
+        self.assertIn("2025-01-31", irrigation_insert)
+        self.assertIn("conditional_change_event", irrigation_insert)
+        # columna renombrada de source a org_id
+        self.assertIn("source as org_id", irrigation_insert.lower())
+
+        # --- Tabla agg ---
+        irrigation_agg = next(
+            (s for s in normalized if "create or replace table irrigation_org-id_agg" in s.lower()),
+            None,
+        )
+        self.assertIsNotNone(irrigation_agg, "Debe crear tabla irrigation_{org_id}_agg")
+        self.assertIn("irrigation_reading_sum_cf", irrigation_agg)
+        self.assertIn("total_reading_sum_cf", irrigation_agg)
+        self.assertNotIn("irrigation_detection_agg", irrigation_agg)
+
+    def test_exec_postprocessor__irrigation_tables_not_shared(self):
+        """
+        Verifica que NO se crea la tabla compartida vieja irrigation_detection_agg.
+        """
+        min_date = datetime.datetime(2025, 1, 1, tzinfo=pytz.UTC)
+        max_date = datetime.datetime(2025, 1, 31, tzinfo=pytz.UTC)
+
+        self.snowflake_sink.exec_postprocessor("run-id", min_date, max_date)
+
+        all_sqls = " ".join(
+            call[0][0] for call in self.mock_cursor.execute.call_args_list
+        )
+        self.assertNotIn(
+            "irrigation_detection_agg",
+            all_sqls,
+            "No debe crear la tabla compartida vieja irrigation_detection_agg",
+        )
+
     def test_store_raw(self):
         self.snowflake_sink.store_raw(
             "run-id",


### PR DESCRIPTION
Currently, the post-processor creates a single shared irrigation_detection_agg table using CREATE OR REPLACE, with no org scoping and no detail-level data. This PR brings irrigation events in line with how leak events are handled.

Changes:

Replace the shared irrigation_detection_agg table with per-org tables:
irrigation_{org_id} — detail table (one row per reading) with idempotent DELETE + INSERT by date window
irrigation_{org_id}_agg — aggregated table (one row per event) rebuilt via CREATE OR REPLACE from the detail table
Filter wavelet.global_irrigation_detection by source = org_id to scope data per organization
Rename the source column to org_id in all output tables
Add unit tests verifying the correct SQL execution order, table names, date window filtering, and that the old shared table is no longer created