### PR TITLE
Detect completed backfills and clamp range to min_date

### DIFF
--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -634,9 +634,13 @@ class ExtractRangeCalculator:
 
         sink = snowflake_sink[0]
         end = sink.calculate_end_of_backfill_range(self.org_id, min_date, max_date)
-        if not end:
+        if not end or end <= min_date:
             raise Exception(
                 f"No backfillable days found between {min_date} and {max_date} for {self.org_id}, consider removing this backfill from the configuration."
             )
-        start = end - timedelta(days=interval_days)
+        start = max(end - timedelta(days=interval_days), min_date)
+        if start >= end:
+            raise Exception(
+                f"No backfillable days found between {min_date} and {max_date} for {self.org_id}, consider removing this backfill from the configuration."
+            )
         return start, end


### PR DESCRIPTION
## Summary

- When a backfill completes (fills all data in its configured range), the range calculator would return a date before `min_date`, causing empty extracts that cascade into `JSONDecodeError` failures on every subsequent run
- The existing completion check (`if not end:`) could never trigger because `calculate_end_of_backfill_range` always returns a truthy datetime
- Now raises a clean "No backfillable days found, consider removing this backfill" exception when the backfill reaches the beginning of its range
- Also clamps `start` to `min_date` to prevent overshooting past the configured range boundary

## Context

Discovered during the Hillsborough Data Lake backfill. After the backfill completed, 29 consecutive runs failed with `JSONDecodeError` because they were extracting date ranges before the data existed.

## Test plan

- [x] Traced through all scenarios: first run, active backfill, completion, near-completion, partial first day, existing adapters
- [ ] Existing tests pass (shared infrastructure change — verify no regressions)