### PR TITLE
Fix timezone comparison in backfill range calculation

### DIFF
--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -634,6 +634,9 @@ class ExtractRangeCalculator:
 
         sink = snowflake_sink[0]
         end = sink.calculate_end_of_backfill_range(self.org_id, min_date, max_date)
+        # Ensure min_date is tz-aware if end is (Snowflake returns tz-aware timestamps)
+        if end and end.tzinfo is not None and min_date.tzinfo is None:
+            min_date = min_date.replace(tzinfo=end.tzinfo)
         if not end or end <= min_date:
             raise Exception(
                 f"No backfillable days found between {min_date} and {max_date} for {self.org_id}, consider removing this backfill from the configuration."


### PR DESCRIPTION
## Summary
- Snowflake returns timezone-aware timestamps but backfill config stores naive datetimes
- The `end <= min_date` check added in PR #213 raises `TypeError: can't compare offset-naive and offset-aware datetimes` for any new backfill
- First seen with `cadc_crescent` backfill
- Fix: normalize `min_date` to match `end`'s timezone before comparing

## Test plan
- [x] Verified fix handles all edge cases (end=None, both naive, both aware, mixed)
- [ ] Merge, deploy, confirm cadc_crescent backfill DAG succeeds