### PR TITLE
Improve Superset auth error message on unexpected response shape

### DIFF
--- a/amiadapters/adapters/xylem_datalake.py
+++ b/amiadapters/adapters/xylem_datalake.py
@@ -190,7 +190,12 @@ def _create_superset_session(
         raise RuntimeError(
             f"Superset login failed (status {me_resp.status_code}): {me_resp.text[:300]}"
         )
-    user = me_resp.json()["result"]
+    me_data = me_resp.json()
+    if "result" not in me_data:
+        raise RuntimeError(
+            f"Superset login returned unexpected shape (status {me_resp.status_code}): {me_resp.text[:300]}"
+        )
+    user = me_data["result"]
     logger.info(f"Authenticated as {user['username']}")
 
     # Step 5: CSRF token


### PR DESCRIPTION
## Summary

When `/api/v1/me/` returns valid JSON without a `result` key, the code crashed with `KeyError: 'result'` and dropped the response body. Adds a guard mirroring the Content-Type check above so the actual response text surfaces in logs.

## Context

`cadc_crescent-ami-meter-read-dag-standard` failed on 2026-04-29 with `KeyError: 'result'` at `xylem_datalake.py:193`. Root cause is unknown because the error swallowed the response. Likely candidates: expired Keycloak session, rate-limit, or Superset error envelope. This change makes future occurrences self-diagnosing.

## Test plan

- [ ] CI Black check passes
- [ ] Verify on next Crescent/Hills run that auth still succeeds (no regression on the happy path)
- [ ] If the failure recurs, the new RuntimeError surfaces the body so we can fix the actual cause