### PR TITLE
Replace percentile heuristic with MIN(flowtime) for backfill chunk selection

### DIFF
--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import datetime, time
+from datetime import datetime
 import logging
 from typing import List, Set
 

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -1005,16 +1005,18 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
         # heuristic that got stuck on orgs whose leading edge had
         # below-threshold per-day read volume (legitimate ramp-up at the
         # start of vendor data).
-        result = conn.cursor().execute(
+        cursor = conn.cursor()
+        cursor.execute(
             """
             SELECT MIN(flowtime) FROM readings
             WHERE org_id = ? AND flowtime > ? AND flowtime < ?
             """,
             (org_id, min_date, max_date),
-        ).fetchall()
-        if not result or result[0][0] is None:
+        )
+        row = cursor.fetchone()
+        if row is None or row[0] is None:
             return max_date
-        return result[0][0]
+        return row[0]
 
 
 class SnowflakeMetersUniqueByDeviceIdCheck(BaseAMIDataQualityCheck):

--- a/amiadapters/storage/snowflake.py
+++ b/amiadapters/storage/snowflake.py
@@ -999,53 +999,22 @@ class SnowflakeStorageSink(BaseAMIStorageSink):
             logger.info(f"Set earliest to {next_end.isoformat()}")
             return earliest
 
-        # Calculate nth percentile of number of readings per day
-        # We will use that as a threshold for what we consider "already backfilled"
-        percentile_query = """
-        SELECT PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY num_readings) AS nth_percentile
-        FROM (
-            SELECT count(*) as num_readings 
-            FROM readings WHERE org_id = ? AND flowtime > ? AND flowtime < ? 
-            GROUP BY date(flowtime)
-        )
-        """
-        percentile_result = conn.cursor().execute(
-            percentile_query, (org_id, min_date, max_date)
-        )
-        percentile_rows = [i for i in percentile_result]
-        if len(percentile_rows) != 1:
-            threshold = 0
-        else:
-            threshold = float(percentile_rows[0][0])
-
-        # Lower threshold by x% to allow dates with legitimately lower volume to be considered backfilled
-        threshold = 0.5 * threshold
-
-        # Find the oldest day in the range that we've already backfilled
-        query = """
-        SELECT MIN(flow_date) from (
-            SELECT DATE(flowtime) as flow_date 
-            FROM readings 
-            WHERE org_id = ? AND flowtime > ? AND flowtime < ?
-            GROUP BY DATE(flowtime)
-            HAVING COUNT(*) > ?
-        ) 
-        """
+        # Use MIN(flowtime) as the leading edge of already-backfilled data.
+        # Each successful chunk pushes MIN earlier, so the next chunk
+        # advances naturally. Replaces an earlier percentile-threshold
+        # heuristic that got stuck on orgs whose leading edge had
+        # below-threshold per-day read volume (legitimate ramp-up at the
+        # start of vendor data).
         result = conn.cursor().execute(
-            query,
-            (
-                org_id,
-                min_date,
-                max_date,
-                threshold,
-            ),
-        )
-        rows = [i for i in result]
-        if rows is None or len(rows) != 1 or rows[0][0] is None:
+            """
+            SELECT MIN(flowtime) FROM readings
+            WHERE org_id = ? AND flowtime > ? AND flowtime < ?
+            """,
+            (org_id, min_date, max_date),
+        ).fetchall()
+        if not result or result[0][0] is None:
             return max_date
-
-        result = rows[0][0]
-        return datetime.combine(result, time(0, 0))
+        return result[0][0]
 
 
 class SnowflakeMetersUniqueByDeviceIdCheck(BaseAMIDataQualityCheck):

--- a/test/amiadapters/storage/test_snowflake.py
+++ b/test/amiadapters/storage/test_snowflake.py
@@ -472,3 +472,27 @@ class TestSnowflakeStorageSink(BaseTestCase):
             reads[1].flowtime,
             oldest_flowtime,
         )
+
+    def test_calculate_end_of_backfill_range__returns_min_flowtime(self):
+        expected_min = datetime.datetime(2024, 11, 29, 19, 0, tzinfo=pytz.UTC)
+        self.mock_cursor.execute.return_value.fetchall.return_value = [(expected_min,)]
+
+        result = self.snowflake_sink.calculate_end_of_backfill_range(
+            "some_org",
+            datetime.datetime(2023, 1, 1),
+            datetime.datetime(2026, 4, 23),
+        )
+
+        self.assertEqual(expected_min, result)
+
+    def test_calculate_end_of_backfill_range__returns_max_date_when_no_readings(self):
+        max_date = datetime.datetime(2026, 4, 23)
+        self.mock_cursor.execute.return_value.fetchall.return_value = [(None,)]
+
+        result = self.snowflake_sink.calculate_end_of_backfill_range(
+            "some_org",
+            datetime.datetime(2023, 1, 1),
+            max_date,
+        )
+
+        self.assertEqual(max_date, result)

--- a/test/amiadapters/storage/test_snowflake.py
+++ b/test/amiadapters/storage/test_snowflake.py
@@ -475,7 +475,7 @@ class TestSnowflakeStorageSink(BaseTestCase):
 
     def test_calculate_end_of_backfill_range__returns_min_flowtime(self):
         expected_min = datetime.datetime(2024, 11, 29, 19, 0, tzinfo=pytz.UTC)
-        self.mock_cursor.execute.return_value.fetchall.return_value = [(expected_min,)]
+        self.mock_cursor.fetchone.return_value = (expected_min,)
 
         result = self.snowflake_sink.calculate_end_of_backfill_range(
             "some_org",
@@ -487,7 +487,7 @@ class TestSnowflakeStorageSink(BaseTestCase):
 
     def test_calculate_end_of_backfill_range__returns_max_date_when_no_readings(self):
         max_date = datetime.datetime(2026, 4, 23)
-        self.mock_cursor.execute.return_value.fetchall.return_value = [(None,)]
+        self.mock_cursor.fetchone.return_value = (None,)
 
         result = self.snowflake_sink.calculate_end_of_backfill_range(
             "some_org",


### PR DESCRIPTION
## Summary

`SnowflakeStorageSink.calculate_end_of_backfill_range` used a percentile-threshold heuristic to identify the leading edge of already-backfilled data. The heuristic returns `MIN(date)` filtered to days whose read count exceeds 50% of the 75th-percentile of daily counts. This gets stuck when an org's leading edge has below-threshold per-day volume — typically the legitimate ramp-up period at the start of vendor data.

`cadc_crescent`'s backfill DAG has been silently re-processing the same `(2024-11-29, 2024-12-29)` chunk every run for ~2 weeks. Xylem has data back to 2023-01-01 (the configured backfill min_date), but our `MIN(flowtime)` hasn't moved because the chunker keeps targeting data we already have.

## Change

Replace the percentile heuristic with raw `MIN(flowtime)` over the configured range. After each successful chunk, `MIN(flowtime)` shifts earlier, so the next run picks an older chunk automatically. No state tracking, no per-org branches.

## What was considered and rejected

- **Per-org Crescent override** following the `cadc_thousand_oaks` pattern: works but adds another per-org hack on top of an existing one.
- **Explicit `backfill_progress` state table**: more invasive, schema change, not needed for the immediate fix.
- **Keeping the heuristic with a smarter threshold**: complex, doesn't solve the underlying conflation of "ramp-up" with "partial load."

## Trade-off

The new approach gives up one narrow case the old heuristic handled: a transient ETL failure that loaded a partial day at the leading edge would self-heal on retry under the old logic. With raw MIN, a partial leading-edge day would persist; recovery requires a manual DAG run on that range. This case is narrow in practice (most partials are middle-of-range, where neither approach helps), and the data-gap quality check `notify_on_failure()` is `False` anyway, so the old behavior was self-healing without operator visibility.

## Affected orgs

Only `cadc_crescent` has an active backfill DAG (verified via `configuration_backfills`). Spot-checked READINGS shape per org — only stray-shape candidates were `cadc_thousand_oaks` (handled by its own branch, untouched here) and `cadc_moulton_niguel` (no backfill DAG). No regression risk for any other org.

## Follow-up

The `cadc_thousand_oaks` branch + orphan `backfills` table row will be cleaned up in a separate PR.

## Test plan

- [x] Existing unit tests pass (239/239)
- [ ] Deploy via \`./deploy.sh cadc\`
- [ ] Watch next scheduled Crescent backfill run (every 2h, \`0 */2 * * *\`)
- [ ] Confirm \`Extracting data for range\` log line shows older chunk (e.g. \`2024-10-30 → 2024-11-29\`) instead of \`2024-11-29 → 2024-12-29\`
- [ ] Re-query Snowflake for \`MIN(flowtime) WHERE org_id = 'cadc_crescent'\` after a few runs — should march backward toward 2023-01-01