### PR TITLE
Raise clear error when load step finds empty transformed extract

### DIFF
--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -215,6 +215,15 @@ class BaseAMIAdapter(ABC):
         with self._base_adapter_metrics.load_transformed_timer():
             meters = self.output_controller.read_transformed_meters(run_id)
             reads = self.output_controller.read_transformed_meter_reads(run_id)
+            if not meters or not reads:
+                raise Exception(
+                    f"Extract for {self.org_id} (run_id={run_id}) produced "
+                    f"{len(meters)} meters and {len(reads)} reads. "
+                    f"If this is a backfill DAG that has reached the vendor's data floor, "
+                    f"decommission it with: "
+                    f"`python cli.py config remove-backfill {self.org_id} <start_date> <end_date> --profile <profile>`. "
+                    f"Otherwise this likely indicates a vendor outage or authentication failure."
+                )
             for sink in self.storage_sinks:
                 sink.store_transformed(run_id, meters, reads)
 

--- a/amiadapters/outputs/local.py
+++ b/amiadapters/outputs/local.py
@@ -65,7 +65,12 @@ class LocalTaskOutputController(BaseTaskOutputController):
         logger.info(f"Reading meters from {path}")
         with open(path, "r") as f:
             text = f.read()
-            meters = [GeneralMeter(**json.loads(d)) for d in text.strip().split("\n")]
+            if not text.strip():
+                meters = []
+            else:
+                meters = [
+                    GeneralMeter(**json.loads(d)) for d in text.strip().split("\n")
+                ]
         logger.info(f"Read {len(meters)} meters from {path}")
         return meters
 
@@ -84,9 +89,12 @@ class LocalTaskOutputController(BaseTaskOutputController):
         logger.info(f"Reading meter reads from {path}")
         with open(path, "r") as f:
             text = f.read()
-            reads = [
-                GeneralMeterRead(**json.loads(d)) for d in text.strip().split("\n")
-            ]
+            if not text.strip():
+                reads = []
+            else:
+                reads = [
+                    GeneralMeterRead(**json.loads(d)) for d in text.strip().split("\n")
+                ]
         logger.info(f"Read {len(reads)} meter reads from {path}")
         return reads
 

--- a/amiadapters/outputs/s3.py
+++ b/amiadapters/outputs/s3.py
@@ -89,6 +89,8 @@ class S3TaskOutputController(BaseTaskOutputController):
         key = self._s3_key(run_id, self.TRANSFORM, "meters.json.gz")
         logger.info(f"Downloading meters from s3://{self.bucket_name}/{key}")
         text = self._download_string_from_s3(key)
+        if not text.strip():
+            return []
         return [GeneralMeter(**json.loads(line)) for line in text.strip().split("\n")]
 
     def write_transformed_meter_reads(self, run_id: str, reads: List[GeneralMeterRead]):
@@ -101,6 +103,8 @@ class S3TaskOutputController(BaseTaskOutputController):
         key = self._s3_key(run_id, self.TRANSFORM, "reads.json.gz")
         logger.info(f"Downloading reads from s3://{self.bucket_name}/{key}")
         text = self._download_string_from_s3(key)
+        if not text.strip():
+            return []
         return [
             GeneralMeterRead(**json.loads(line)) for line in text.strip().split("\n")
         ]

--- a/test/amiadapters/outputs/test_local.py
+++ b/test/amiadapters/outputs/test_local.py
@@ -146,3 +146,13 @@ class TestLocalTaskOutputController(BaseTestCase):
         self.assertEqual(reads_out[0].device_id, "1")
         self.assertEqual(reads_out[0].register_value, 123.4)
         self.assertEqual(reads_out[1].device_id, "2")
+
+    def test_read_transformed_meters__empty_file_returns_empty_list(self):
+        self.controller.write_transformed_meters("run123", [])
+        result = self.controller.read_transformed_meters("run123")
+        self.assertEqual([], result)
+
+    def test_read_transformed_meter_reads__empty_file_returns_empty_list(self):
+        self.controller.write_transformed_meter_reads("run123", [])
+        result = self.controller.read_transformed_meter_reads("run123")
+        self.assertEqual([], result)

--- a/test/amiadapters/outputs/test_s3.py
+++ b/test/amiadapters/outputs/test_s3.py
@@ -168,6 +168,20 @@ class TestS3TaskOutputController(BaseTestCase):
         self.assertEqual(result[1].device_id, "2")
         self.assertEqual(result[1].register_value, 227.6)
 
+    def test_read_transformed_meters__empty_file_returns_empty_list(self):
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=lambda: self._gzip(""))
+        }
+        result = self.controller.read_transformed_meters("runid")
+        self.assertEqual([], result)
+
+    def test_read_transformed_meter_reads__empty_file_returns_empty_list(self):
+        self.mock_s3.get_object.return_value = {
+            "Body": MagicMock(read=lambda: self._gzip(""))
+        }
+        result = self.controller.read_transformed_meter_reads("runid")
+        self.assertEqual([], result)
+
     def _gzip(self, content: str) -> bytes:
         buf = io.BytesIO()
         with gzip.GzipFile(fileobj=buf, mode="wb") as gz:

--- a/test/amiadapters/test_base.py
+++ b/test/amiadapters/test_base.py
@@ -279,3 +279,68 @@ class TestExtractRangeCalculator(BaseTestCase):
             self.calculator.calculate_extract_range(
                 None, None, backfill_params=backfill_params
             )
+
+
+class TestLoadTransformed(BaseTestCase):
+
+    def setUp(self):
+        self.adapter = Beacon360Adapter(
+            api_user="user",
+            api_password="pass",
+            use_cache=False,
+            pipeline_configuration=self.TEST_PIPELINE_CONFIGURATION,
+            org_id="test-org",
+            org_timezone=pytz.timezone("Europe/Rome"),
+            configured_task_output_controller=self.TEST_TASK_OUTPUT_CONTROLLER_CONFIGURATION,
+            configured_metrics=self.TEST_METRICS_CONFIGURATION,
+            configured_sinks=[],
+        )
+        self.adapter.output_controller = MagicMock()
+        self.sink = MagicMock()
+        self.adapter.storage_sinks = [self.sink]
+
+    def test_load_transformed__happy_path_calls_sink(self):
+        self.adapter.output_controller.read_transformed_meters.return_value = [
+            MagicMock()
+        ]
+        self.adapter.output_controller.read_transformed_meter_reads.return_value = [
+            MagicMock()
+        ]
+
+        self.adapter.load_transformed("run-1")
+
+        self.sink.store_transformed.assert_called_once()
+
+    def test_load_transformed__raises_when_meters_empty(self):
+        self.adapter.output_controller.read_transformed_meters.return_value = []
+        self.adapter.output_controller.read_transformed_meter_reads.return_value = [
+            MagicMock()
+        ]
+
+        with self.assertRaises(Exception) as cm:
+            self.adapter.load_transformed("run-1")
+
+        self.assertIn("remove-backfill", str(cm.exception))
+        self.sink.store_transformed.assert_not_called()
+
+    def test_load_transformed__raises_when_reads_empty(self):
+        self.adapter.output_controller.read_transformed_meters.return_value = [
+            MagicMock()
+        ]
+        self.adapter.output_controller.read_transformed_meter_reads.return_value = []
+
+        with self.assertRaises(Exception) as cm:
+            self.adapter.load_transformed("run-1")
+
+        self.assertIn("remove-backfill", str(cm.exception))
+        self.sink.store_transformed.assert_not_called()
+
+    def test_load_transformed__raises_when_both_empty(self):
+        self.adapter.output_controller.read_transformed_meters.return_value = []
+        self.adapter.output_controller.read_transformed_meter_reads.return_value = []
+
+        with self.assertRaises(Exception) as cm:
+            self.adapter.load_transformed("run-1")
+
+        self.assertIn("remove-backfill", str(cm.exception))
+        self.sink.store_transformed.assert_not_called()


### PR DESCRIPTION
## Problem

When `load_transformed` encounters an empty `reads.json.gz` (or `meters.json.gz`) at S3, it crashes inside the `_default_decoder.decode()` chain with `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`. The failure notifier fires, but the alert is cryptic — no signal as to what the underlying state is.

This has been happening every 2 hours on the `cadc_crescent-ami-meter-read-dag-backfill-2023-01-01-2026-04-23` DAG since the backfill marched past the vendor's earliest reading (`2023-01-01 16:00 UTC`). The xylem_datalake adapter queries the `account` table with no date filter, so the meters file is always non-empty (~7,750 accounts); the `water_intervals` / `water_registers` queries are date-filtered, so for pre-floor chunks they return zero rows and the reads file is empty.

## Why the existing check doesn't catch this

`_calculate_backfill_range` at `amiadapters/adapters/base.py:652-655` raises "consider removing this backfill" when `end <= min_date` (where `end = MIN(flowtime)` from existing readings). For Crescent, `MIN(flowtime) = 2023-01-01 16:00 UTC` and the configured `min_date = 2023-01-01 00:00` — `end > min_date` forever, because the vendor's data floor sits 16 hours above the configured floor. The check is structurally incapable of firing for any org whose vendor floor is strictly above its configured `min_date`. The PR #222 review flagged this completion edge case at the time.

A stateless pre-extract check cannot detect "vendor has no more data" — that signal only exists after asking the vendor. The natural place for the check is post-extract.

## Changes

1. **`amiadapters/outputs/s3.py`** and **`amiadapters/outputs/local.py`**: `read_transformed_meters` and `read_transformed_meter_reads` return `[]` instead of crashing when the file is empty (just defensive — empty input should never produce `JSONDecodeError`).
2. **`amiadapters/adapters/base.py`**: in `load_transformed`, if either `meters` or `reads` is empty, raise a clear exception with the decommission CLI suggestion. Fires the existing failure notifier with an alert message that tells the operator what to do.

The exception message handles both completion and outage cases:
- Backfill at vendor floor → "decommission with `python cli.py config remove-backfill ...`"
- Standard / lagged / manual DAG anomaly (vendor outage, auth failure) → "this likely indicates a vendor outage or authentication failure"

## Per-adapter safety check

I spot-checked each adapter to make sure no live path produces empty meters+reads under healthy steady-state operation:

| Adapter | Empty on healthy run? |
|---|---|
| xylem_datalake | Only for pre-floor chunks (Crescent's exact case) — completion signal |
| aclara | No — `load_from_file` on `meters_and_reads.json` already errors in transform without `allow_empty=True` |
| beacon | No — report query errors before load |
| sentryx | No — 0 meters or 0 reads is real anomaly |
| subeca | No — every account has a `latestReading` |
| metersense | Uncertain — uses `allow_empty=True` for sub-files. Realistically a 2-day Oracle window with 0 reads on an active utility is highly unlikely |
| xylem_moulton_niguel | Same as metersense |
| xylem_sensus | Not in live production yet (South Tahoe awaiting SFTP creds) |

If the metersense / xylem_moulton_niguel adapters end up firing false-positive alerts in practice, the check can be made adapter-aware in a follow-up. The strict check is the safe default — water-meter telemetry is continuous and zero rows in any reasonable window is worth alerting on.

## Test plan

- [x] `test/amiadapters/outputs/test_s3.py` — 2 new tests for empty-file return-`[]` behavior
- [x] `test/amiadapters/outputs/test_local.py` — 2 new tests for the same in `LocalTaskOutputController`
- [x] `test/amiadapters/test_base.py` — 4 new tests covering `load_transformed` happy path + empty meters / empty reads / both empty
- [x] Full unit test suite passes (249 tests)
- [x] Black formatting check passes
- [ ] After merge + deploy: verify Crescent's next backfill run fails with the new exception text rather than `JSONDecodeError`, then decommission the backfill DAG