### PR TITLE
Widen sink post-process window to cover extract ranges older than 30 days

### DIFF
--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -232,6 +232,7 @@ class BaseAMIAdapter(ABC):
         run_id: str,
         extract_range_start: datetime,
         extract_range_end: datetime,
+        widen_post_process_window: bool = False,
     ):
         """
         Post processing step after loading data into storage sinks. Includes
@@ -248,10 +249,13 @@ class BaseAMIAdapter(ABC):
                     sink_post_process_start_date = (
                         sink_post_process_end_date - timedelta(days=30)
                     )
-                    # If this run extracted data older than the default window, widen the
-                    # window backwards so that data is post processed too. Scheduled runs
-                    # always extract within the last 30 days, so their window is unchanged.
-                    if extract_range_start is not None:
+                    # A manual run whose trigger conf explicitly provided an extract range
+                    # older than the default window may widen the window backwards so that
+                    # data is post processed too. Scheduled and backfill runs must never
+                    # widen: their computed ranges can reach far into history (lagged
+                    # extracts, backfill chunks), which would repeatedly rewrite
+                    # historical post-processor output on every run.
+                    if widen_post_process_window and extract_range_start is not None:
                         extract_start = extract_range_start
                         if extract_start.tzinfo is not None:
                             extract_start = extract_start.replace(tzinfo=None)

--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -238,6 +238,11 @@ class BaseAMIAdapter(ABC):
         Post processing step after loading data into storage sinks. Includes
         sink-specific post processing, e.g. queries that run on the loaded data to refresh downstream tables.
 
+        widen_post_process_window: when True and extract_range_start is older than the
+        default trailing-30-day window, widen the sink post-process window backwards to
+        include it. Callers should set this only for runs whose range was explicitly
+        provided by an operator.
+
         Also can be configured to publish an event to a message queue saying we finished loading data.
         """
         with self._base_adapter_metrics.post_process_timer():

--- a/amiadapters/adapters/base.py
+++ b/amiadapters/adapters/base.py
@@ -248,6 +248,16 @@ class BaseAMIAdapter(ABC):
                     sink_post_process_start_date = (
                         sink_post_process_end_date - timedelta(days=30)
                     )
+                    # If this run extracted data older than the default window, widen the
+                    # window backwards so that data is post processed too. Scheduled runs
+                    # always extract within the last 30 days, so their window is unchanged.
+                    if extract_range_start is not None:
+                        extract_start = extract_range_start
+                        if extract_start.tzinfo is not None:
+                            extract_start = extract_start.replace(tzinfo=None)
+                        sink_post_process_start_date = min(
+                            sink_post_process_start_date, extract_start
+                        )
                     logger.info(
                         f"Running post processor for sink {sink.__class__.__name__} from {sink_post_process_start_date} to {sink_post_process_end_date}"
                     )

--- a/amicontrol/dags/meter_read_dags.py
+++ b/amicontrol/dags/meter_read_dags.py
@@ -61,7 +61,11 @@ def ami_control_dag_factory(
         def post_process(**context):
             run_id = context["dag_run"].run_id
             start, end = _calculate_extract_range(adapter, context, interval, lag)
-            adapter.post_process(run_id, start, end)
+            # Only a run whose extract range was explicitly provided in the trigger
+            # conf may widen the sink post-process window. Scheduled and backfill
+            # runs have no user-provided range and must keep the default window.
+            widen = bool(context["params"].get("extract_range_start"))
+            adapter.post_process(run_id, start, end, widen_post_process_window=widen)
 
         # Set sequence of tasks for this utility
         (

--- a/amicontrol/dags/meter_read_dags.py
+++ b/amicontrol/dags/meter_read_dags.py
@@ -62,9 +62,13 @@ def ami_control_dag_factory(
             run_id = context["dag_run"].run_id
             start, end = _calculate_extract_range(adapter, context, interval, lag)
             # Only a run whose extract range was explicitly provided in the trigger
-            # conf may widen the sink post-process window. Scheduled and backfill
-            # runs have no user-provided range and must keep the default window.
-            widen = bool(context["params"].get("extract_range_start"))
+            # conf may widen the sink post-process window. Backfill runs must never
+            # widen — they ignore conf and compute historical chunk ranges — and
+            # Airflow merges dag_run.conf into params even for DAGs that declare no
+            # params, so the conf check alone would not exclude them.
+            widen = backfill_params is None and bool(
+                context["params"].get("extract_range_start")
+            )
             adapter.post_process(run_id, start, end, widen_post_process_window=widen)
 
         # Set sequence of tasks for this utility

--- a/test/amiadapters/test_base.py
+++ b/test/amiadapters/test_base.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytz
@@ -111,6 +111,66 @@ class TestBaseAdapter(BaseTestCase):
     def test_map_reading__unrecognized_unit(self):
         with self.assertRaises(ValueError, msg="Unrecognized unit of measure: Pounds"):
             self.adapter.map_reading(5.0, "Pounds")
+
+    @patch("amiadapters.adapters.base.datetime")
+    def test_post_process__window_unchanged_for_recent_extract_range(
+        self, mock_datetime
+    ):
+        today = datetime(2026, 8, 13, 12, 0, 0)
+        mock_datetime.today.return_value = today
+        sink = MagicMock(spec=SnowflakeStorageSink)
+        self.adapter.storage_sinks = [sink]
+
+        self.adapter.post_process("run-id", today - timedelta(days=2), today)
+
+        sink.exec_postprocessor.assert_called_once_with(
+            "run-id", today - timedelta(days=30), today
+        )
+
+    @patch("amiadapters.adapters.base.datetime")
+    def test_post_process__window_widens_backwards_for_old_extract_range(
+        self, mock_datetime
+    ):
+        today = datetime(2026, 8, 13, 12, 0, 0)
+        mock_datetime.today.return_value = today
+        sink = MagicMock(spec=SnowflakeStorageSink)
+        self.adapter.storage_sinks = [sink]
+        old_start = datetime(2026, 5, 14)
+
+        self.adapter.post_process("run-id", old_start, datetime(2026, 5, 15))
+
+        sink.exec_postprocessor.assert_called_once_with("run-id", old_start, today)
+
+    @patch("amiadapters.adapters.base.datetime")
+    def test_post_process__window_widens_for_timezone_aware_extract_range(
+        self, mock_datetime
+    ):
+        today = datetime(2026, 8, 13, 12, 0, 0)
+        mock_datetime.today.return_value = today
+        sink = MagicMock(spec=SnowflakeStorageSink)
+        self.adapter.storage_sinks = [sink]
+        aware_start = datetime(2026, 5, 14, tzinfo=timezone.utc)
+
+        self.adapter.post_process("run-id", aware_start, datetime(2026, 5, 15))
+
+        sink.exec_postprocessor.assert_called_once_with(
+            "run-id", datetime(2026, 5, 14), today
+        )
+
+    @patch("amiadapters.adapters.base.datetime")
+    def test_post_process__window_unchanged_when_extract_range_is_none(
+        self, mock_datetime
+    ):
+        today = datetime(2026, 8, 13, 12, 0, 0)
+        mock_datetime.today.return_value = today
+        sink = MagicMock(spec=SnowflakeStorageSink)
+        self.adapter.storage_sinks = [sink]
+
+        self.adapter.post_process("run-id", None, None)
+
+        sink.exec_postprocessor.assert_called_once_with(
+            "run-id", today - timedelta(days=30), today
+        )
 
 
 class TestExtractRangeCalculator(BaseTestCase):

--- a/test/amiadapters/test_base.py
+++ b/test/amiadapters/test_base.py
@@ -121,14 +121,35 @@ class TestBaseAdapter(BaseTestCase):
         sink = MagicMock(spec=SnowflakeStorageSink)
         self.adapter.storage_sinks = [sink]
 
-        self.adapter.post_process("run-id", today - timedelta(days=2), today)
+        self.adapter.post_process(
+            "run-id", today - timedelta(days=2), today, widen_post_process_window=True
+        )
 
         sink.exec_postprocessor.assert_called_once_with(
             "run-id", today - timedelta(days=30), today
         )
 
     @patch("amiadapters.adapters.base.datetime")
-    def test_post_process__window_widens_backwards_for_old_extract_range(
+    def test_post_process__old_extract_range_does_not_widen_window_by_default(
+        self, mock_datetime
+    ):
+        # Scheduled and backfill runs pass computed ranges that can reach far into
+        # history (lagged extracts, backfill chunks); they must keep the default window.
+        today = datetime(2026, 8, 13, 12, 0, 0)
+        mock_datetime.today.return_value = today
+        sink = MagicMock(spec=SnowflakeStorageSink)
+        self.adapter.storage_sinks = [sink]
+
+        self.adapter.post_process(
+            "run-id", datetime(2026, 2, 13), datetime(2026, 2, 14)
+        )
+
+        sink.exec_postprocessor.assert_called_once_with(
+            "run-id", today - timedelta(days=30), today
+        )
+
+    @patch("amiadapters.adapters.base.datetime")
+    def test_post_process__window_widens_backwards_for_old_extract_range_when_enabled(
         self, mock_datetime
     ):
         today = datetime(2026, 8, 13, 12, 0, 0)
@@ -137,7 +158,9 @@ class TestBaseAdapter(BaseTestCase):
         self.adapter.storage_sinks = [sink]
         old_start = datetime(2026, 5, 14)
 
-        self.adapter.post_process("run-id", old_start, datetime(2026, 5, 15))
+        self.adapter.post_process(
+            "run-id", old_start, datetime(2026, 5, 15), widen_post_process_window=True
+        )
 
         sink.exec_postprocessor.assert_called_once_with("run-id", old_start, today)
 
@@ -151,7 +174,12 @@ class TestBaseAdapter(BaseTestCase):
         self.adapter.storage_sinks = [sink]
         aware_start = datetime(2026, 5, 14, tzinfo=timezone.utc)
 
-        self.adapter.post_process("run-id", aware_start, datetime(2026, 5, 15))
+        self.adapter.post_process(
+            "run-id",
+            aware_start,
+            datetime(2026, 5, 15),
+            widen_post_process_window=True,
+        )
 
         sink.exec_postprocessor.assert_called_once_with(
             "run-id", datetime(2026, 5, 14), today


### PR DESCRIPTION
## Problem

`BaseAMIAdapter.post_process` receives the run's extract range but discards it: the sink post-processor window is always `[today - 30 days, today]` (`amiadapters/adapters/base.py`). Data loaded for dates older than 30 days is therefore never post-processed — the window-scoped `LEAKS_*`/`IRRIGATION_*` DELETE+INSERTs can never reach it, on any DAG type. Manual-DAG conf ranges and backfill chunk ranges are both computed and passed down by the DAG's `post_process` task, then ignored at this layer.

Motivating incident: the irrigation detection task was down 5/21–7/24. When `GLOBAL_IRRIGATION_DETECTION` was backfilled on 7/24–25, the per-org `IRRIGATION_*` tables could no longer pick up the restored May–June event dates, because every post-process window had already moved past them. All six detection orgs have the resulting hole, and no DAG run can repair it with the current code.

## Change

Two pieces:

1. `BaseAMIAdapter.post_process` gains a `widen_post_process_window` flag (default `False`). When set and `extract_range_start` is older than the default window start, the window widens backwards to `[extract_range_start, today]`. Timezone-aware starts are normalized to naive before comparison (manual conf params parse timezone-aware when given an ISO string with an offset; `datetime.today()` is naive).
2. The DAG's `post_process` task sets the flag only when the trigger conf explicitly provided `extract_range_start`. Scheduled and backfill runs therefore never widen.

The gating is load-bearing, not cosmetic. An earlier version of this branch widened whenever `extract_range_start` was old, on the assumption that scheduled runs always extract within the last 30 days. Review found that assumption false on two counts:

- Beacon's half-year-lagged scheduled extract (`beacon.py`, `lag=timedelta(days=6*30)`) would have post-processed a ~181-day window on every daily run.
- Backfill DAGs recompute their range after the chunk loads (`calculate_end_of_backfill_range` uses `MIN(flowtime)`), so each chunk would have post-processed `[chunk_start, today]`, growing toward the backfill floor on every run.

With the flag, both keep the default 30-day window unconditionally.

## Operational notes for wide manual runs

A widened window drives the whole monolithic post-processor, not just the irrigation step: `METERS_SCORE_*` is org-wide-replaced on the wider window's statistical basis until the next scheduled run overwrites it, and `LEAKS_*` history inside the window is deleted and re-derived from readings (event boundaries and `event_start_ts` values can differ from what the original 30-day runs stored, which also re-keys events for downstream consumers that key on `ACCOUNT_ID` + `EVENT_START_TS`). Wide manual runs should be deliberate about their start date and run clear of the scheduled daily runs.

## Tests

Five tests in `test/amiadapters/test_base.py`: recent range with widening enabled → default window (the `min()` floor); old range without the flag → default window (pins the gating); old range with the flag → widened; timezone-aware old range → normalized and widened; `None` → default. Full suite: 336 passed; the 9 Snowflake integration errors are the known env-dependent ones. `black` clean.